### PR TITLE
add GitHub SECURITY.md policy for vulnerability disclosure

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Supported Versions
+
+This project follows a rolling release strategy. Only the `main` branch is actively maintained and receives security updates.
+
+| Branch | Supported |
+|--------|-----------|
+| main   | ✅        |
+| others | ❌        |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please **do not create a public issue**.
+
+Instead, responsibly disclose it by emailing:
+shopkeeper@unattributed.blog
+
+We aim to acknowledge your report within **3 business days** and provide a fix or mitigation plan within **7–14 days**, depending on severity.
+Thank you for helping us keep this project secure.


### PR DESCRIPTION
This commit adds a SECURITY.md policy file to define supported versions and responsible vulnerability disclosure instructions.
