### PR TITLE
Add contextual model size selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A lightweight local Web UI for chatting with models served by Ollama. The Python
 
 - Local browser UI for Ollama models
 - Newest-first model selector from Ollama's public model library, with `models.json` as a fallback
+- Contextual size selector so pulls and chats use a specific available model tag
 - Local installed model detection through Ollama `/api/tags`
 - Streaming prompt responses through Ollama `/api/generate`
 - Streaming model downloads through Ollama `/api/pull`
@@ -84,14 +85,14 @@ http://127.0.0.1:11435/
 
 Do not open `index.html` directly with a `file://` URL. Use the Flask helper URL so the UI, pull endpoint, and Ollama generation proxy all share the same local origin.
 
-The model selector is scoped to Ollama models that are suitable for this chat UI's `/api/generate` workflow. Embedding-only models, such as text embedding models, are intentionally excluded from the remote catalog because they are not applicable for conversational prompt/response generation in this application.
+The model selector is scoped to Ollama models that are suitable for this chat UI's local `/api/generate` workflow. Embedding-only models, such as text embedding models, and cloud-only models are intentionally excluded from the remote catalog because they are not applicable for local pull-and-run chat in this application.
 
 ## Pull a Model
 
-Use the Web UI button, or test the pull endpoint directly:
+Use the Web UI model and size selectors, or test the pull endpoint directly with a full model tag:
 
 ```bash
-curl -N 'http://127.0.0.1:11435/pull_model?model=deepseek-r1&pull_id=manual-test'
+curl -N 'http://127.0.0.1:11435/pull_model?model=deepseek-r1:7b&pull_id=manual-test'
 ```
 
 While a pull is active, the Web UI changes the pull button to `Cancel Pull`. Cancelling closes the active upstream Ollama pull stream for that request.

--- a/index.html
+++ b/index.html
@@ -14,6 +14,8 @@
       <div class="model-controls">
         <label for="model-select">Model</label>
         <select id="model-select" aria-label="Choose model"></select>
+        <label for="size-select">Size</label>
+        <select id="size-select" aria-label="Choose model size"></select>
         <button type="button" id="pull-model">Pull Model</button>
       </div>
       <div id="model-description" class="model-description" aria-live="polite"></div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 Flask==3.1.3
-flask-cors==6.0.1
 requests==2.33.0

--- a/script.js
+++ b/script.js
@@ -3,6 +3,7 @@ const chatContainer = document.getElementById('chat-container');
 const promptForm = document.getElementById('prompt-form');
 const promptInput = document.getElementById('prompt-input');
 const modelSelect = document.getElementById('model-select');
+const sizeSelect = document.getElementById('size-select');
 const fileInput = document.getElementById('file-input');
 const filePreview = document.getElementById('file-preview');
 const pullModelButton = document.getElementById('pull-model');
@@ -10,6 +11,7 @@ const modelDescription = document.getElementById('model-description');
 const submitButton = document.getElementById('submit-btn');
 
 let currentModel = 'deepseek-r1';
+let currentSize = '';
 let modelsMap = {};
 let installedModels = new Set();
 let currentPull = null;
@@ -63,11 +65,84 @@ function createPullId() {
   return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 }
 
+function splitModelReference(value) {
+  const name = String(value || '').trim();
+  const lastColon = name.lastIndexOf(':');
+  const lastSlash = name.lastIndexOf('/');
+
+  if (lastColon > lastSlash) {
+    return {
+      baseName: name.slice(0, lastColon),
+      tag: name.slice(lastColon + 1),
+    };
+  }
+
+  return { baseName: name, tag: '' };
+}
+
+function uniqueValues(values) {
+  const seen = new Set();
+  return values.filter((value) => {
+    const normalized = String(value || '').trim();
+    const key = normalized.toLowerCase();
+    if (!normalized || seen.has(key)) {
+      return false;
+    }
+
+    seen.add(key);
+    return true;
+  });
+}
+
+function addSizeToModel(modelName, size) {
+  const normalized = String(size || '').trim();
+  if (!modelName || !normalized || normalized.toLowerCase() === 'latest' || !modelsMap[modelName]) {
+    return;
+  }
+
+  const sizes = Array.isArray(modelsMap[modelName].sizes) ? modelsMap[modelName].sizes : [];
+  modelsMap[modelName].sizes = uniqueValues([...sizes, normalized]);
+}
+
+function installedSizesForModel(modelName) {
+  const sizes = [];
+  installedModels.forEach((installedName) => {
+    const { baseName, tag } = splitModelReference(installedName);
+    if (baseName === modelName && tag && tag.toLowerCase() !== 'latest') {
+      sizes.push(tag);
+    }
+  });
+
+  return uniqueValues(sizes);
+}
+
+function getModelSizes(modelName) {
+  const model = modelsMap[modelName];
+  const catalogSizes = model && Array.isArray(model.sizes) ? model.sizes : [];
+  return uniqueValues([...catalogSizes, ...installedSizesForModel(modelName)]);
+}
+
+function selectedModelReference() {
+  const modelName = modelSelect.value;
+  const size = sizeSelect.value;
+  return modelName && size ? `${modelName}:${size}` : modelName;
+}
+
+function isModelInstalled(modelName, size = '') {
+  if (!modelName) {
+    return false;
+  }
+
+  const modelReference = size ? `${modelName}:${size}` : modelName;
+  return installedModels.has(modelReference) || (!size && installedModels.has(`${modelName}:latest`));
+}
+
 function setPullControls(isPulling) {
   promptInput.placeholder = isPulling ? 'Pulling model...' : 'Send a message...';
   pullModelButton.textContent = isPulling ? 'Cancel Pull' : 'Pull Model';
   pullModelButton.disabled = false;
   modelSelect.disabled = isPulling;
+  sizeSelect.disabled = isPulling || sizeSelect.options.length <= 1;
 }
 
 function finishPull(statusText = null) {
@@ -89,6 +164,30 @@ function parseGenerateLine(line) {
   } catch {
     throw new Error(`invalid stream response from /api/generate: ${previewText(line)}`);
   }
+}
+
+function populateSizeSelect(modelName) {
+  const sizes = getModelSizes(modelName);
+  const preferredSize = sizes.includes(currentSize) ? currentSize : sizes[0] || '';
+
+  sizeSelect.replaceChildren();
+  if (sizes.length) {
+    sizes.forEach((size) => {
+      const option = document.createElement('option');
+      option.value = size;
+      option.textContent = size;
+      sizeSelect.appendChild(option);
+    });
+  } else {
+    const option = document.createElement('option');
+    option.value = '';
+    option.textContent = 'default';
+    sizeSelect.appendChild(option);
+  }
+
+  sizeSelect.value = preferredSize;
+  currentSize = sizeSelect.value;
+  sizeSelect.disabled = Boolean(currentPull) || sizes.length <= 1;
 }
 
 function setModelDescription(modelName) {
@@ -114,9 +213,11 @@ function setModelDescription(modelName) {
   }
 
   const installed = document.createElement('div');
-  installed.textContent = installedModels.has(modelName) || installedModels.has(`${modelName}:latest`)
+  const selectedSize = sizeSelect.value;
+  const modelReference = selectedModelReference();
+  installed.textContent = isModelInstalled(modelName, selectedSize)
     ? 'Local status: installed'
-    : 'Local status: not detected locally';
+    : `Local status: ${modelReference} not detected locally`;
 
   const detailNodes = details.map((detail) => {
     const node = document.createElement('div');
@@ -169,15 +270,20 @@ function addModelOption(model) {
 
 function addInstalledModelsToCatalog() {
   installedModels.forEach((name) => {
-    const baseName = name.endsWith(':latest') ? name.slice(0, -7) : name;
-    if (modelsMap[baseName] || modelsMap[name]) {
+    const { baseName, tag } = splitModelReference(name);
+    if (modelsMap[baseName]) {
+      addSizeToModel(baseName, tag);
+      return;
+    }
+    if (modelsMap[name]) {
       return;
     }
 
     addModelOption({
-      name,
+      name: baseName,
       description: 'Installed local Ollama model.',
       updated: 'local',
+      sizes: tag && tag.toLowerCase() !== 'latest' ? [tag] : [],
     });
   });
 }
@@ -200,10 +306,12 @@ async function fetchModels() {
       modelSelect.value = currentModel;
     }
 
+    populateSizeSelect(modelSelect.value);
     setModelDescription(modelSelect.value);
   } catch (error) {
     appendStatus(`Unable to load model catalog: ${error.message}`);
     modelSelect.disabled = true;
+    sizeSelect.disabled = true;
     pullModelButton.disabled = true;
     submitButton.disabled = true;
   }
@@ -215,7 +323,8 @@ function pullSelectedModel() {
     return;
   }
 
-  const model = modelSelect.value;
+  const modelName = modelSelect.value;
+  const model = selectedModelReference();
   if (!model) {
     appendStatus('No model selected.');
     return;
@@ -252,8 +361,13 @@ function pullSelectedModel() {
 
     if (line.toLowerCase().startsWith('success:')) {
       installedModels.add(model);
-      installedModels.add(`${model}:latest`);
-      setModelDescription(model);
+      if (!sizeSelect.value) {
+        installedModels.add(`${model}:latest`);
+      }
+      addSizeToModel(modelName, sizeSelect.value);
+      setModelDescription(modelName);
+      finishPull();
+    } else if (line.toLowerCase().startsWith('error:')) {
       finishPull();
     }
   };
@@ -306,7 +420,7 @@ async function submitPrompt(event) {
   event.preventDefault();
 
   const prompt = promptInput.value.trim();
-  const model = modelSelect.value;
+  const model = selectedModelReference();
   if (!prompt || !model) {
     return;
   }
@@ -396,6 +510,12 @@ promptForm.addEventListener('submit', submitPrompt);
 fileInput.addEventListener('change', previewSelectedFiles);
 modelSelect.addEventListener('change', () => {
   currentModel = modelSelect.value;
+  currentSize = '';
+  populateSizeSelect(currentModel);
+  setModelDescription(currentModel);
+});
+sizeSelect.addEventListener('change', () => {
+  currentSize = sizeSelect.value;
   setModelDescription(currentModel);
 });
 window.addEventListener('DOMContentLoaded', fetchModels);

--- a/scripts/pull_model.py
+++ b/scripts/pull_model.py
@@ -63,6 +63,7 @@ class OllamaLibraryParser(HTMLParser):
                 "updated": "",
                 "capabilities": [],
                 "sizes": [],
+                "badges": [],
             }
             self._depth = 1
             return
@@ -81,6 +82,8 @@ class OllamaLibraryParser(HTMLParser):
             self._start_capture("sizes")
         elif tag == "span" and "x-test-updated" in attrs_map:
             self._start_capture("updated")
+        elif tag == "span" and "text-cyan-500" in (attrs_map.get("class") or ""):
+            self._start_capture("badges")
 
     def handle_data(self, data: str) -> None:
         if self._capture:
@@ -93,7 +96,7 @@ class OllamaLibraryParser(HTMLParser):
         if self._capture:
             value = " ".join("".join(self._capture_parts).split())
             if value:
-                if self._capture in {"capabilities", "sizes"}:
+                if self._capture in {"capabilities", "sizes", "badges"}:
                     self._current[self._capture].append(value)
                 else:
                     self._current[self._capture] = value
@@ -114,9 +117,13 @@ class OllamaLibraryParser(HTMLParser):
 
         name = str(self._current.get("name", "")).strip()
         capabilities = self._current.get("capabilities", [])
+        sizes = self._current.get("sizes", [])
+        badges = [str(badge).lower() for badge in self._current.get("badges", [])]
         is_embedding_only = capabilities == ["embedding"]
-        if name and name not in self._seen_names and not is_embedding_only:
+        is_cloud_only = "cloud" in badges and not sizes
+        if name and name not in self._seen_names and not is_embedding_only and not is_cloud_only:
             self._seen_names.add(name)
+            self._current.pop("badges", None)
             self.models.append(self._current)
 
         self._current = None
@@ -370,6 +377,7 @@ def pull_model() -> Response | tuple[Response, int]:
 
     @stream_with_context
     def stream_pull() -> Iterator[str]:
+        pull_error: str | None = None
         try:
             yield sse_line(f"pulling {model}")
             with upstream:
@@ -384,6 +392,12 @@ def pull_model() -> Response | tuple[Response, int]:
                         yield sse_line(line)
                         continue
 
+                    error = event.get("error")
+                    if error:
+                        pull_error = str(error)
+                        yield sse_line(f"error: {pull_error}")
+                        break
+
                     status = str(event.get("status", "progress"))
                     completed = event.get("completed")
                     total = event.get("total")
@@ -394,7 +408,8 @@ def pull_model() -> Response | tuple[Response, int]:
                     else:
                         yield sse_line(status)
 
-            yield sse_line("success: model pull completed")
+            if pull_error is None and not is_pull_cancelled(pull_id):
+                yield sse_line("success: model pull completed")
         except Exception as exc:
             if not is_pull_cancelled(pull_id):
                 yield sse_line(f"pull interrupted: {exc}")

--- a/scripts/pull_model.py
+++ b/scripts/pull_model.py
@@ -20,7 +20,6 @@ from typing import Any, Iterator
 
 import requests
 from flask import Flask, Response, jsonify, request, send_from_directory, stream_with_context
-from flask_cors import CORS
 from werkzeug.exceptions import HTTPException
 
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -38,7 +37,6 @@ cancelled_pulls: set[str] = set()
 active_pulls_lock = Lock()
 
 app = Flask(__name__, static_folder=str(BASE_DIR), static_url_path="")
-CORS(app, resources={r"/*": {"origins": ["http://127.0.0.1:11435", "http://localhost:11435"]}})
 
 
 class OllamaLibraryParser(HTMLParser):

--- a/style.css
+++ b/style.css
@@ -126,7 +126,8 @@ footer {
 }
 
 #prompt-input,
-#model-select {
+#model-select,
+#size-select {
   padding: 0.5rem;
   border-radius: 5px;
   background-color: #1e1e1e;
@@ -150,7 +151,8 @@ button {
 
 button:disabled,
 #prompt-input:disabled,
-#model-select:disabled {
+#model-select:disabled,
+#size-select:disabled {
   cursor: not-allowed;
   opacity: 0.6;
 }


### PR DESCRIPTION
## Summary
- add a size dropdown populated from the selected model's available sizes
- use the selected model tag for pull and generate requests
- surface Ollama pull stream errors and filter cloud-only catalog entries

## Verification
- python3 -m py_compile scripts/pull_model.py scripts/deploy_full_ollama_ui.py
- git diff --check
- curl http://127.0.0.1:11435/health
- confirmed /api/models includes contextual sizes for deepseek-r1 and excludes deepseek-v4-flash