### PR TITLE
Support extensionless text uploads

### DIFF
--- a/script.js
+++ b/script.js
@@ -186,7 +186,12 @@ function isTextLikeFile(file) {
     return true;
   }
 
-  return TEXT_FILE_EXTENSIONS.has(fileExtension(file.name));
+  const extension = fileExtension(file.name);
+  if (!extension && (!file.type || file.type === 'application/octet-stream')) {
+    return true;
+  }
+
+  return TEXT_FILE_EXTENSIONS.has(extension);
 }
 
 function formatBytes(value) {


### PR DESCRIPTION
## Summary
- accept extensionless text-like uploads such as Unix maillog files when browsers report no MIME type or application/octet-stream

## Verification
- python3 -m py_compile scripts/pull_model.py scripts/deploy_full_ollama_ui.py
- .venv/bin/python -m pip_audit -r requirements.txt
- git diff --check