### PR TITLE
Add Ollama model type filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ http://127.0.0.1:11435/
 
 Do not open `index.html` directly with a `file://` URL. Use the Flask helper URL so the UI, pull endpoint, and Ollama generation proxy all share the same local origin.
 
-The model selector defaults to `Any`, which shows every catalog model the helper can read from Ollama, sorted by the newest `Updated` timestamp exposed by the site. `Code Development` is a local convenience filter, not an official Ollama category; it matches coding-oriented model names and descriptions while the other type filters map directly to Ollama capability tags where available.
+The model selector defaults to `Any`, which shows every catalog model the helper can read from Ollama, sorted by the newest `Updated` timestamp exposed by the site. `Code Development` is a local convenience filter, not an official Ollama category; it matches coding-oriented model names and descriptions while the other type filters map directly to Ollama capability tags where available. Cloud-only catalog entries remain visible, but the Web UI disables local pull and chat controls for entries that do not expose a local Ollama manifest.
 
 ## Pull a Model
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A lightweight local Web UI for chatting with models served by Ollama. The Python
 - Streaming model downloads through Ollama `/api/pull`
 - Cancel button for an active model pull
 - Text-like file analysis through prompt context
+- Project Agent panel for scoped local project guardrails, file search/read, and allowlisted development tool execution
 - Same-origin Flask proxy to avoid direct browser CORS issues
 
 ## Requirements
@@ -103,6 +104,19 @@ While a pull is active, the Web UI changes the pull button to `Cancel Pull`. Can
 Use `Upload File(s)` to select text-like files such as Markdown, plain text, code, CSV, JSON, XML, YAML, or logs. The browser reads supported files locally and adds their contents to the next prompt sent to Ollama.
 
 Click `Analyze Files` to send a default analysis request, or type your own question and press `Send`. Large files are skipped or truncated before being added to the prompt so local models are not overloaded.
+
+## Project Agent
+
+Use the Project Agent panel to give Ollama bounded local project context before asking for coding help. The default project is `/home/foo/Workspace/OSMAP` when it exists.
+
+- `Load Project` validates the project root and summarizes available text files and docs.
+- `Add Guardrails` retrieves relevant chunks from `docs/**/*.md` plus root project docs such as `README.md` and `SECURITY.md`.
+- `Search` finds matching lines in text-like project files.
+- `Read File` attaches one project-relative text file to the next prompt.
+- `Run Tool` executes an allowlisted local development command under the project root and attaches stdout/stderr to the next prompt.
+- `Clear Context` removes accumulated project context from future prompts.
+
+Project access is restricted to directories under `OLLAMA_WEBUI_PROJECT_ROOTS`, which defaults to `~/Workspace`. The helper skips large files and directories such as `.git`, `.venv`, `target`, `node_modules`, and caches. Tool execution does not use a shell. The current allowlist covers read-only Git commands, common Cargo subcommands, `rustc`, `pytest`, `ruff`, `mypy`, and `python -m` modules such as `pytest`, `py_compile`, `compileall`, `ruff`, `mypy`, and `unittest`.
 
 ## Smoke Test
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,25 @@
 # Ollama Web UI
 
-A lightweight local Web UI for chatting with models served by Ollama. The Python helper serves the static frontend, proxies browser requests to the local Ollama API, streams model pull progress, and streams generation responses back to the browser.
+Ollama Web UI is an intentionally insecure local lab application for chatting with models served by Ollama.
+
+This project is not a secure product, not a hardened assistant, and not a production-ready AI coding environment. It has no intentional focus on security. It is deliberately useful as a weak, inspectable browser-based LLM target for the AI Browser Security Test Suite in the same spirit that OWASP Juice Shop is useful as an intentionally vulnerable web application.
+
+Use it only on a machine and projects you control. The Project Agent feature can read local files under configured workspace roots and run allowlisted local development tools. That behavior is dangerous by design if pointed at real sensitive repositories or if exposed beyond localhost.
+
+The Python helper serves the static frontend, proxies browser requests to the local Ollama API, streams model pull progress, streams generation responses back to the browser, and exposes intentionally simple local project helper endpoints for testing.
+
+## Insecure Lab Warning
+
+This application deliberately does not provide production security controls:
+
+- no authentication or multi-user isolation
+- no hardened browser sandbox
+- no protection against prompt injection or model manipulation
+- no guarantee that uploaded files, local project files, or tool output are handled safely
+- no robust secret detection, redaction, policy engine, or audit boundary
+- no safe-by-default authorization model for local file and tool access beyond simple local path and command allowlists
+
+The expected use case is local defensive research, browser-AI testing, and controlled demonstrations by the AI Browser Security Test Suite. Do not bind it to public interfaces, do not use it with production secrets, and do not treat model responses as security decisions.
 
 ## Features
 
@@ -108,6 +127,12 @@ Click `Analyze Files` to send a default analysis request, or type your own quest
 ## Project Agent
 
 Use the Project Agent panel to give Ollama bounded local project context before asking for coding help. The default project is `/home/foo/Workspace/OSMAP` when it exists.
+
+This is a lab feature, not a secure coding agent. Treat every project file,
+tool result, and generated answer as untrusted. The feature exists so the test
+suite can demonstrate how local project evidence enters an LLM context and why
+real systems need stronger isolation, policy controls, redaction, approvals,
+and auditing.
 
 - `Load Project` validates the project root and summarizes available text files and docs.
 - `Add Guardrails` retrieves relevant chunks from `docs/**/*.md` plus root project docs such as `README.md` and `SECURITY.md`.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A lightweight local Web UI for chatting with models served by Ollama. The Python
 
 - Local browser UI for Ollama models
 - Newest-first model selector from Ollama's public model library, with `models.json` as a fallback
-- Model type filter with `Any`, `Code Development`, and Ollama capability types such as `Tools`, `Thinking`, `Vision`, `Audio`, `Cloud`, and `Embedding`
+- Model type filter with `Any`, `Code Development`, and Ollama capability types such as `Tools`, `Thinking`, `Vision`, `Audio`, and `Embedding`
 - Contextual size selector so pulls and chats use a specific available model tag
 - Local installed model detection through Ollama `/api/tags`
 - Streaming prompt responses through Ollama `/api/generate`
@@ -86,7 +86,7 @@ http://127.0.0.1:11435/
 
 Do not open `index.html` directly with a `file://` URL. Use the Flask helper URL so the UI, pull endpoint, and Ollama generation proxy all share the same local origin.
 
-The model selector defaults to `Any`, which shows every catalog model the helper can read from Ollama, sorted by the newest `Updated` timestamp exposed by the site. `Code Development` is a local convenience filter, not an official Ollama category; it matches coding-oriented model names and descriptions while the other type filters map directly to Ollama capability tags where available. Cloud-only catalog entries remain visible, but the Web UI disables local pull and chat controls for entries that do not expose a local Ollama manifest.
+The model selector defaults to `Any`, which shows locally pullable catalog models the helper can read from Ollama, sorted by the newest `Updated` timestamp exposed by the site. `Code Development` is a local convenience filter, not an official Ollama category; it matches coding-oriented model names and descriptions while the other type filters map directly to Ollama capability tags where available. Cloud-only catalog entries are excluded because this Web UI is built around local Ollama pull and chat workflows.
 
 ## Pull a Model
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A lightweight local Web UI for chatting with models served by Ollama. The Python
 
 - Local browser UI for Ollama models
 - Newest-first model selector from Ollama's public model library, with `models.json` as a fallback
+- Model type filter with `Any`, `Code Development`, and Ollama capability types such as `Tools`, `Thinking`, `Vision`, `Audio`, `Cloud`, and `Embedding`
 - Contextual size selector so pulls and chats use a specific available model tag
 - Local installed model detection through Ollama `/api/tags`
 - Streaming prompt responses through Ollama `/api/generate`
@@ -85,7 +86,7 @@ http://127.0.0.1:11435/
 
 Do not open `index.html` directly with a `file://` URL. Use the Flask helper URL so the UI, pull endpoint, and Ollama generation proxy all share the same local origin.
 
-The model selector is scoped to Ollama models that are suitable for this chat UI's local `/api/generate` workflow. Embedding-only models, such as text embedding models, and cloud-only models are intentionally excluded from the remote catalog because they are not applicable for local pull-and-run chat in this application.
+The model selector defaults to `Any`, which shows every catalog model the helper can read from Ollama, sorted by the newest `Updated` timestamp exposed by the site. `Code Development` is a local convenience filter, not an official Ollama category; it matches coding-oriented model names and descriptions while the other type filters map directly to Ollama capability tags where available.
 
 ## Pull a Model
 

--- a/index.html
+++ b/index.html
@@ -12,6 +12,8 @@
     <header>
       <div class="title">🧠 Ollama Web UI</div>
       <div class="model-controls">
+        <label for="model-type-select">Type</label>
+        <select id="model-type-select" aria-label="Filter models by type"></select>
         <label for="model-select">Model</label>
         <select id="model-select" aria-label="Choose model"></select>
         <label for="size-select">Size</label>

--- a/index.html
+++ b/index.html
@@ -25,6 +25,35 @@
 
     <main id="chat-container" aria-live="polite"></main>
 
+    <section id="project-agent-area" aria-label="Project Agent">
+      <div class="project-agent-grid">
+        <label>
+          Project
+          <input type="text" id="project-root-input" value="/home/foo/Workspace/OSMAP" />
+        </label>
+        <button type="button" id="load-project-btn">Load Project</button>
+        <label>
+          Query
+          <input type="text" id="project-query-input" placeholder="security guardrails, architecture, coding task..." />
+        </label>
+        <button type="button" id="project-context-btn">Add Guardrails</button>
+        <label>
+          File
+          <input type="text" id="project-file-input" placeholder="docs/SECURITY_MODEL.md" />
+        </label>
+        <button type="button" id="project-read-btn">Read File</button>
+        <label>
+          Tool
+          <input type="text" id="project-command-input" placeholder="cargo test" />
+        </label>
+        <button type="button" id="project-run-btn">Run Tool</button>
+        <button type="button" id="project-search-btn">Search</button>
+        <button type="button" id="project-clear-btn">Clear Context</button>
+      </div>
+      <div id="project-agent-status"></div>
+      <pre id="project-agent-preview"></pre>
+    </section>
+
     <div id="upload-area">
       <input type="file" id="file-input" multiple />
       <div class="upload-controls">

--- a/models.json
+++ b/models.json
@@ -35,20 +35,6 @@
     "sizes": ["128b"]
   },
   {
-    "name": "deepseek-v4-flash",
-    "description": "DeepSeek-V4-Flash is a preview of the DeepSeek-V4 series, a Mixture-of-Experts model with 284B total parameters and 13B activated, built for efficient reasoning across a 1M-token context window.",
-    "updated": "3 weeks ago",
-    "capabilities": ["tools", "thinking"],
-    "sizes": []
-  },
-  {
-    "name": "deepseek-v4-pro",
-    "description": "DeepSeek-V4-Pro is a frontier Mixture-of-Experts model with a 1M-token context window and three reasoning modes.",
-    "updated": "3 weeks ago",
-    "capabilities": ["tools", "thinking"],
-    "sizes": []
-  },
-  {
     "name": "laguna-xs.2",
     "description": "Laguna XS.2 is a 33B total parameter Mixture-of-Experts model with 3B activated parameters per token designed for agentic coding and long-horizon work on a local machine.",
     "updated": "3 weeks ago",
@@ -61,13 +47,6 @@
     "updated": "3 weeks ago",
     "capabilities": ["vision", "tools", "thinking", "audio"],
     "sizes": ["33b"]
-  },
-  {
-    "name": "glm-5.1",
-    "description": "GLM-5.1 is our next-generation flagship model for agentic engineering, with significantly stronger coding capabilities than its predecessor. It achieves state-of-the-art performance on SWE-Bench Pro and leads GLM-5 by a wide margin.",
-    "updated": "1 month ago",
-    "capabilities": ["tools", "thinking"],
-    "sizes": []
   },
   {
     "name": "kimi-k2.6",

--- a/models.json
+++ b/models.json
@@ -1,52 +1,114 @@
 [
   {
+    "name": "gemma4",
+    "description": "Gemma 4 models are designed to deliver frontier-level performance at each size. They are well-suited for reasoning, agentic workflows, coding, and multimodal understanding.",
+    "updated": "4 hours ago",
+    "capabilities": ["vision", "tools", "thinking", "audio"],
+    "sizes": ["e2b", "e4b", "26b", "31b"]
+  },
+  {
+    "name": "qwen3.5",
+    "description": "Qwen 3.5 is a family of open-source multimodal models that delivers exceptional utility and performance.",
+    "updated": "4 hours ago",
+    "capabilities": ["vision", "tools", "thinking"],
+    "sizes": ["0.8b", "2b", "4b", "9b", "27b", "35b", "122b"]
+  },
+  {
+    "name": "qwen3.6",
+    "description": "Qwen3.6 delivers substantial upgrades in agentic coding and thinking preservation than previous Qwen models.",
+    "updated": "5 hours ago",
+    "capabilities": ["vision", "tools", "thinking"],
+    "sizes": ["27b", "35b"]
+  },
+  {
+    "name": "granite4.1",
+    "description": "IBM Granite Models are a family of enterprise-ready, open foundation models that support multilingual capabilities, coding, retrieval-augmented generation (RAG), tool use, and structured JSON output. Released under Apache 2.0 license.",
+    "updated": "2 days ago",
+    "capabilities": ["tools"],
+    "sizes": ["3b", "8b", "30b"]
+  },
+  {
+    "name": "mistral-medium-3.5",
+    "description": "Mistral Medium 3.5 is the first flagship model of Mistral AI that merged instruction-following, reasoning, and coding in a single set of 128B weights.",
+    "updated": "2 weeks ago",
+    "capabilities": ["vision", "tools", "thinking"],
+    "sizes": ["128b"]
+  },
+  {
+    "name": "deepseek-v4-flash",
+    "description": "DeepSeek-V4-Flash is a preview of the DeepSeek-V4 series, a Mixture-of-Experts model with 284B total parameters and 13B activated, built for efficient reasoning across a 1M-token context window.",
+    "updated": "3 weeks ago",
+    "capabilities": ["tools", "thinking"],
+    "sizes": []
+  },
+  {
+    "name": "deepseek-v4-pro",
+    "description": "DeepSeek-V4-Pro is a frontier Mixture-of-Experts model with a 1M-token context window and three reasoning modes.",
+    "updated": "3 weeks ago",
+    "capabilities": ["tools", "thinking"],
+    "sizes": []
+  },
+  {
+    "name": "laguna-xs.2",
+    "description": "Laguna XS.2 is a 33B total parameter Mixture-of-Experts model with 3B activated parameters per token designed for agentic coding and long-horizon work on a local machine.",
+    "updated": "3 weeks ago",
+    "capabilities": ["tools", "thinking"],
+    "sizes": []
+  },
+  {
+    "name": "nemotron3",
+    "description": "NVIDIA Nemotron 3 Nano Omni is a multimodal large language model that unifies video, audio, image, and text understanding to support enterprise-grade Q&A, summarization, transcription, and document intelligence workflows.",
+    "updated": "3 weeks ago",
+    "capabilities": ["vision", "tools", "thinking", "audio"],
+    "sizes": ["33b"]
+  },
+  {
+    "name": "glm-5.1",
+    "description": "GLM-5.1 is our next-generation flagship model for agentic engineering, with significantly stronger coding capabilities than its predecessor. It achieves state-of-the-art performance on SWE-Bench Pro and leads GLM-5 by a wide margin.",
+    "updated": "1 month ago",
+    "capabilities": ["tools", "thinking"],
+    "sizes": []
+  },
+  {
+    "name": "kimi-k2.6",
+    "description": "Kimi K2.6 is an open-source, native multimodal agentic model that advances practical capabilities in long-horizon coding, coding-driven design, proactive autonomous execution, and swarm-based task orchestration.",
+    "updated": "1 month ago",
+    "capabilities": ["vision", "tools", "thinking"],
+    "sizes": []
+  },
+  {
+    "name": "minimax-m2.7",
+    "description": "MiniMax's M2-series model for coding, agentic workflows, and professional productivity.",
+    "updated": "2 months ago",
+    "capabilities": ["tools", "thinking"],
+    "sizes": []
+  },
+  {
+    "name": "qwen3-coder-next",
+    "description": "Qwen3-Coder-Next is a coding-focused language model from Alibaba's Qwen team, optimized for agentic coding workflows and local development.",
+    "updated": "3 months ago",
+    "capabilities": ["tools"],
+    "sizes": []
+  },
+  {
+    "name": "gpt-oss",
+    "description": "OpenAI's open-weight models designed for powerful reasoning, agentic tasks, and versatile developer use cases.",
+    "updated": "6 months ago",
+    "capabilities": ["tools", "thinking"],
+    "sizes": ["20b", "120b"]
+  },
+  {
     "name": "deepseek-r1",
     "description": "DeepSeek-R1 is a family of open reasoning models with performance approaching that of leading models, such as O3 and Gemini 2.5 Pro.",
-    "updated": "2 days ago"
+    "updated": "10 months ago",
+    "capabilities": ["tools", "thinking"],
+    "sizes": ["1.5b", "7b", "8b", "14b", "32b", "70b", "671b"]
   },
   {
-    "name": "llama4",
-    "description": "Meta's latest collection of multimodal models.",
-    "updated": "2 days ago"
-  },
-  {
-    "name": "qwen3",
-    "description": "Qwen3 is the latest generation of large language models in Qwen series, offering a comprehensive suite of dense and mixture-of-experts (MoE) models.",
-    "updated": "3 weeks ago"
-  },
-  {
-    "name": "qwen2.5vl",
-    "description": "Flagship vision-language model of Qwen and also a significant leap from the previous Qwen2-VL.",
-    "updated": "3 weeks ago"
-  },
-  {
-    "name": "devstral",
-    "description": "Devstral: the best open source model for coding agents",
-    "updated": "4 weeks ago"
-  },
-  {
-    "name": "gemma3",
-    "description": "The current, most capable model that runs on a single GPU.",
-    "updated": "2 months ago"
-  },
-  {
-    "name": "phi4",
-    "description": "Phi-4 is a 14B parameter, state-of-the-art open model from Microsoft.",
-    "updated": "5 months ago"
-  },
-  {
-    "name": "llama3.1",
-    "description": "Llama 3.1 is a new state-of-the-art model from Meta available in 8B, 70B and 405B parameter sizes.",
-    "updated": "6 months ago"
-  },
-  {
-    "name": "llama3.3",
-    "description": "New state of the art 70B model. Llama 3.3 70B offers similar performance compared to the Llama 3.1 405B model.",
-    "updated": "6 months ago"
-  },
-  {
-    "name": "llama3.2",
-    "description": "Meta's Llama 3.2 goes small with 1B and 3B models.",
-    "updated": "8 months ago"
+    "name": "nomic-embed-text",
+    "description": "A high-performing open embedding model with a large token context window.",
+    "updated": "2 years ago",
+    "capabilities": ["embedding"],
+    "sizes": []
   }
 ]

--- a/script.js
+++ b/script.js
@@ -283,6 +283,29 @@ function isModelInstalled(modelName, size = '') {
   return installedModels.has(modelReference) || (!size && installedModels.has(`${modelName}:latest`));
 }
 
+function isCloudOnlyModel(modelName) {
+  const model = modelsMap[modelName];
+  if (!model || isModelInstalled(modelName)) {
+    return false;
+  }
+
+  return modelCapabilities(model).includes('cloud') && getModelSizes(modelName).length === 0;
+}
+
+function updateSelectedModelControls() {
+  const hasModels = modelSelect.options.length > 0;
+  const cloudOnly = isCloudOnlyModel(currentModel);
+  modelSelect.disabled = Boolean(currentPull) || !hasModels;
+
+  if (!currentPull) {
+    pullModelButton.disabled = !hasModels || cloudOnly;
+    pullModelButton.title = cloudOnly ? 'Cloud-only catalog entry; no local Ollama manifest is available to pull.' : '';
+  }
+
+  submitButton.disabled = !hasModels || cloudOnly;
+  submitButton.title = cloudOnly ? 'Cloud-only catalog entry; local chat generation is not available.' : '';
+}
+
 function fileExtension(fileName) {
   const dotIndex = String(fileName || '').lastIndexOf('.');
   return dotIndex >= 0 ? fileName.slice(dotIndex + 1).toLowerCase() : '';
@@ -347,10 +370,15 @@ function setFileControls(hasFiles) {
 function setPullControls(isPulling) {
   promptInput.placeholder = isPulling ? 'Pulling model...' : 'Send a message...';
   pullModelButton.textContent = isPulling ? 'Cancel Pull' : 'Pull Model';
-  pullModelButton.disabled = false;
   modelTypeSelect.disabled = isPulling;
   modelSelect.disabled = isPulling;
   sizeSelect.disabled = isPulling || sizeSelect.options.length <= 1;
+  if (isPulling) {
+    pullModelButton.disabled = false;
+    pullModelButton.title = '';
+  } else {
+    updateSelectedModelControls();
+  }
 }
 
 function finishPull(statusText = null) {
@@ -377,6 +405,7 @@ function parseGenerateLine(line) {
 function populateSizeSelect(modelName) {
   const sizes = getModelSizes(modelName);
   const preferredSize = sizes.includes(currentSize) ? currentSize : sizes[0] || '';
+  const cloudOnly = isCloudOnlyModel(modelName);
 
   sizeSelect.replaceChildren();
   if (sizes.length) {
@@ -389,7 +418,7 @@ function populateSizeSelect(modelName) {
   } else {
     const option = document.createElement('option');
     option.value = '';
-    option.textContent = 'default';
+    option.textContent = cloudOnly ? 'cloud only' : 'default';
     sizeSelect.appendChild(option);
   }
 
@@ -418,14 +447,20 @@ function setModelDescription(modelName) {
   }
   if (Array.isArray(model.sizes) && model.sizes.length) {
     details.push(`Sizes: ${model.sizes.join(', ')}`);
+  } else if (isCloudOnlyModel(modelName)) {
+    details.push('Local pull: unavailable for this cloud-only catalog entry');
   }
 
   const installed = document.createElement('div');
   const selectedSize = sizeSelect.value;
   const modelReference = selectedModelReference();
-  installed.textContent = isModelInstalled(modelName, selectedSize)
-    ? 'Local status: installed'
-    : `Local status: ${modelReference} not detected locally`;
+  if (isCloudOnlyModel(modelName)) {
+    installed.textContent = 'Local status: no local Ollama manifest is available';
+  } else {
+    installed.textContent = isModelInstalled(modelName, selectedSize)
+      ? 'Local status: installed'
+      : `Local status: ${modelReference} not detected locally`;
+  }
 
   const detailNodes = details.map((detail) => {
     const node = document.createElement('div');
@@ -520,10 +555,7 @@ function renderModelOptions(preferredModel = currentModel) {
 
   populateSizeSelect(currentModel);
   setModelDescription(currentModel);
-  const hasModels = modelSelect.options.length > 0;
-  modelSelect.disabled = Boolean(currentPull) || !hasModels;
-  pullModelButton.disabled = !hasModels;
-  submitButton.disabled = !hasModels;
+  updateSelectedModelControls();
 }
 
 async function fetchModels() {
@@ -552,6 +584,10 @@ function pullSelectedModel() {
 
   const modelName = modelSelect.value;
   const model = selectedModelReference();
+  if (isCloudOnlyModel(modelName)) {
+    appendStatus(`${modelName} is listed as a cloud-only Ollama catalog entry and cannot be pulled into the local Ollama runtime.`);
+    return;
+  }
   if (!model) {
     appendStatus('No model selected.');
     return;
@@ -648,6 +684,10 @@ async function submitPrompt(event) {
 
   const prompt = promptInput.value.trim();
   const model = selectedModelReference();
+  if (isCloudOnlyModel(currentModel)) {
+    appendStatus(`${currentModel} is a cloud-only catalog entry and is not available through this local Ollama chat proxy.`);
+    return;
+  }
   if (!prompt || !model) {
     return;
   }
@@ -810,10 +850,12 @@ modelSelect.addEventListener('change', () => {
   currentSize = '';
   populateSizeSelect(currentModel);
   setModelDescription(currentModel);
+  updateSelectedModelControls();
 });
 sizeSelect.addEventListener('change', () => {
   currentSize = sizeSelect.value;
   setModelDescription(currentModel);
+  updateSelectedModelControls();
 });
 window.addEventListener('DOMContentLoaded', () => {
   populateModelTypeSelect();

--- a/script.js
+++ b/script.js
@@ -2,6 +2,7 @@
 const chatContainer = document.getElementById('chat-container');
 const promptForm = document.getElementById('prompt-form');
 const promptInput = document.getElementById('prompt-input');
+const modelTypeSelect = document.getElementById('model-type-select');
 const modelSelect = document.getElementById('model-select');
 const sizeSelect = document.getElementById('size-select');
 const fileInput = document.getElementById('file-input');
@@ -47,9 +48,40 @@ const TEXT_FILE_EXTENSIONS = new Set([
   'yaml',
   'yml',
 ]);
+const MODEL_TYPE_OPTIONS = [
+  { value: 'any', label: 'Any' },
+  { value: 'code-development', label: 'Code Development' },
+  { value: 'tools', label: 'Tools' },
+  { value: 'thinking', label: 'Thinking' },
+  { value: 'vision', label: 'Vision' },
+  { value: 'audio', label: 'Audio' },
+  { value: 'cloud', label: 'Cloud' },
+  { value: 'embedding', label: 'Embedding' },
+];
+const CODE_DEVELOPMENT_TERMS = [
+  'agentic coding',
+  'code',
+  'coder',
+  'coding',
+  'codellama',
+  'codegemma',
+  'devstral',
+  'developer',
+  'development',
+  'engineering',
+  'magicoder',
+  'phind',
+  'programming',
+  'software',
+  'sql',
+  'starcoder',
+  'swe-bench',
+];
 
 let currentModel = 'deepseek-r1';
 let currentSize = '';
+let currentModelType = 'any';
+let catalogModels = [];
 let modelsMap = {};
 let installedModels = new Set();
 let currentPull = null;
@@ -131,6 +163,81 @@ function uniqueValues(values) {
     seen.add(key);
     return true;
   });
+}
+
+function normalizeCapability(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function modelCapabilities(model) {
+  return Array.isArray(model.capabilities) ? model.capabilities.map(normalizeCapability).filter(Boolean) : [];
+}
+
+function updatedSortValue(model) {
+  const updated = String(model.updated || '').trim().toLowerCase();
+  if (!updated || updated === 'local') {
+    return Number.POSITIVE_INFINITY;
+  }
+  if (updated === 'today' || updated === 'yesterday') {
+    return updated === 'today' ? 0 : 1;
+  }
+
+  const match = updated.match(/(\d+(?:\.\d+)?)\s*(minute|hour|day|week|month|year)s?\s+ago/);
+  if (!match) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  const amount = Number(match[1]);
+  const unitDays = {
+    minute: 1 / 1440,
+    hour: 1 / 24,
+    day: 1,
+    week: 7,
+    month: 30,
+    year: 365,
+  };
+  return amount * unitDays[match[2]];
+}
+
+function compareModelsByRecency(left, right) {
+  const recencyDelta = updatedSortValue(left) - updatedSortValue(right);
+  if (recencyDelta !== 0) {
+    return recencyDelta;
+  }
+
+  return String(left.name || '').localeCompare(String(right.name || ''));
+}
+
+function isCodeDevelopmentModel(model) {
+  const haystack = [
+    model.name,
+    model.description,
+    ...(Array.isArray(model.capabilities) ? model.capabilities : []),
+  ].join(' ').toLowerCase();
+
+  return CODE_DEVELOPMENT_TERMS.some((term) => haystack.includes(term));
+}
+
+function modelMatchesType(model, type) {
+  if (type === 'any') {
+    return true;
+  }
+  if (type === 'code-development') {
+    return isCodeDevelopmentModel(model);
+  }
+
+  return modelCapabilities(model).includes(type);
+}
+
+function populateModelTypeSelect() {
+  modelTypeSelect.replaceChildren();
+  MODEL_TYPE_OPTIONS.forEach((type) => {
+    const option = document.createElement('option');
+    option.value = type.value;
+    option.textContent = type.label;
+    modelTypeSelect.appendChild(option);
+  });
+  modelTypeSelect.value = currentModelType;
 }
 
 function addSizeToModel(modelName, size) {
@@ -241,6 +348,7 @@ function setPullControls(isPulling) {
   promptInput.placeholder = isPulling ? 'Pulling model...' : 'Send a message...';
   pullModelButton.textContent = isPulling ? 'Cancel Pull' : 'Pull Model';
   pullModelButton.disabled = false;
+  modelTypeSelect.disabled = isPulling;
   modelSelect.disabled = isPulling;
   sizeSelect.disabled = isPulling || sizeSelect.options.length <= 1;
 }
@@ -357,11 +465,6 @@ async function fetchModelCatalog() {
 }
 
 function addModelOption(model) {
-  if (!model || !model.name || modelsMap[model.name]) {
-    return;
-  }
-
-  modelsMap[model.name] = model;
   const option = document.createElement('option');
   option.value = model.name;
   option.textContent = model.name;
@@ -371,21 +474,56 @@ function addModelOption(model) {
 function addInstalledModelsToCatalog() {
   installedModels.forEach((name) => {
     const { baseName, tag } = splitModelReference(name);
-    if (modelsMap[baseName]) {
-      addSizeToModel(baseName, tag);
-      return;
-    }
-    if (modelsMap[name]) {
+    const existingModel = catalogModels.find((model) => model.name === baseName);
+    if (existingModel) {
+      const sizes = Array.isArray(existingModel.sizes) ? existingModel.sizes : [];
+      existingModel.sizes = uniqueValues([...sizes, tag]);
       return;
     }
 
-    addModelOption({
+    catalogModels.push({
       name: baseName,
       description: 'Installed local Ollama model.',
       updated: 'local',
+      capabilities: [],
       sizes: tag && tag.toLowerCase() !== 'latest' ? [tag] : [],
     });
   });
+}
+
+function renderModelOptions(preferredModel = currentModel) {
+  modelsMap = {};
+  modelSelect.replaceChildren();
+
+  const filteredModels = catalogModels
+    .filter((model) => model && model.name && modelMatchesType(model, currentModelType))
+    .sort(compareModelsByRecency);
+
+  filteredModels.forEach((model) => {
+    if (modelsMap[model.name]) {
+      return;
+    }
+
+    modelsMap[model.name] = model;
+    addModelOption(model);
+  });
+
+  if (modelsMap[preferredModel]) {
+    currentModel = preferredModel;
+    modelSelect.value = currentModel;
+  } else if (modelSelect.options.length > 0) {
+    currentModel = modelSelect.options[0].value;
+    modelSelect.value = currentModel;
+  } else {
+    currentModel = '';
+  }
+
+  populateSizeSelect(currentModel);
+  setModelDescription(currentModel);
+  const hasModels = modelSelect.options.length > 0;
+  modelSelect.disabled = Boolean(currentPull) || !hasModels;
+  pullModelButton.disabled = !hasModels;
+  submitButton.disabled = !hasModels;
 }
 
 async function fetchModels() {
@@ -393,23 +531,12 @@ async function fetchModels() {
     await fetchInstalledModels();
 
     const models = await fetchModelCatalog();
-    modelsMap = {};
-    modelSelect.replaceChildren();
-
-    models.forEach(addModelOption);
+    catalogModels = Array.isArray(models) ? models.filter((model) => model && model.name) : [];
     addInstalledModelsToCatalog();
-
-    if (modelsMap[currentModel]) {
-      modelSelect.value = currentModel;
-    } else if (modelSelect.options.length > 0) {
-      currentModel = modelSelect.options[0].value;
-      modelSelect.value = currentModel;
-    }
-
-    populateSizeSelect(modelSelect.value);
-    setModelDescription(modelSelect.value);
+    renderModelOptions();
   } catch (error) {
     appendStatus(`Unable to load model catalog: ${error.message}`);
+    modelTypeSelect.disabled = true;
     modelSelect.disabled = true;
     sizeSelect.disabled = true;
     pullModelButton.disabled = true;
@@ -673,6 +800,11 @@ promptForm.addEventListener('submit', submitPrompt);
 fileInput.addEventListener('change', previewSelectedFiles);
 analyzeFilesButton.addEventListener('click', analyzeSelectedFiles);
 clearFilesButton.addEventListener('click', clearSelectedFiles);
+modelTypeSelect.addEventListener('change', () => {
+  currentModelType = modelTypeSelect.value;
+  currentSize = '';
+  renderModelOptions(currentModel);
+});
 modelSelect.addEventListener('change', () => {
   currentModel = modelSelect.value;
   currentSize = '';
@@ -683,4 +815,7 @@ sizeSelect.addEventListener('change', () => {
   currentSize = sizeSelect.value;
   setModelDescription(currentModel);
 });
-window.addEventListener('DOMContentLoaded', fetchModels);
+window.addEventListener('DOMContentLoaded', () => {
+  populateModelTypeSelect();
+  fetchModels();
+});

--- a/script.js
+++ b/script.js
@@ -132,14 +132,74 @@ function responseErrorMessage(response, text) {
 function appendMessage(role, text) {
   const div = document.createElement('div');
   div.className = `message ${role}`;
-  div.textContent = text;
+  const content = document.createElement('div');
+  content.className = 'message-text';
+
+  const copyButton = document.createElement('button');
+  copyButton.type = 'button';
+  copyButton.className = 'message-copy-button';
+  copyButton.textContent = 'Copy';
+  copyButton.title = 'Copy message';
+  copyButton.setAttribute('aria-label', 'Copy message');
+  copyButton.addEventListener('click', () => copyMessageText(copyButton, div));
+
+  div.append(content, copyButton);
   chatContainer.appendChild(div);
+  setMessageText(div, text);
   chatContainer.scrollTop = chatContainer.scrollHeight;
   return div;
 }
 
 function appendStatus(text) {
   return appendMessage('status', text);
+}
+
+function messageTextElement(message) {
+  return message.querySelector('.message-text') || message;
+}
+
+function setMessageText(message, text) {
+  const normalized = String(text || '');
+  messageTextElement(message).textContent = normalized;
+  message.dataset.copyText = normalized;
+}
+
+function appendMessageText(message, text) {
+  setMessageText(message, `${messageTextElement(message).textContent}${text}`);
+  chatContainer.scrollTop = chatContainer.scrollHeight;
+}
+
+async function copyTextToClipboard(text) {
+  if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.left = '-9999px';
+  document.body.appendChild(textarea);
+  textarea.select();
+  document.execCommand('copy');
+  textarea.remove();
+}
+
+async function copyMessageText(button, message) {
+  const originalLabel = button.textContent;
+  const text = message.dataset.copyText || messageTextElement(message).textContent;
+
+  try {
+    await copyTextToClipboard(text);
+    button.textContent = 'Copied';
+  } catch {
+    button.textContent = 'Failed';
+  }
+
+  window.setTimeout(() => {
+    button.textContent = originalLabel;
+  }, 1400);
 }
 
 function createPullId() {
@@ -423,8 +483,7 @@ function finishPull(statusText = null) {
   if (currentPull) {
     currentPull.eventSource.close();
     if (statusText) {
-      currentPull.statusMessage.textContent += `\n${statusText}`;
-      chatContainer.scrollTop = chatContainer.scrollHeight;
+      appendMessageText(currentPull.statusMessage, `\n${statusText}`);
     }
   }
 
@@ -846,8 +905,7 @@ function pullSelectedModel() {
       return;
     }
     currentPull.lastLine = line;
-    statusMessage.textContent += `\n${line}`;
-    chatContainer.scrollTop = chatContainer.scrollHeight;
+    appendMessageText(statusMessage, `\n${line}`);
 
     if (line.toLowerCase().startsWith('success:')) {
       installedModels.add(model);
@@ -879,8 +937,7 @@ async function cancelCurrentPull() {
   const pull = currentPull;
   pull.cancelling = true;
   pullModelButton.disabled = true;
-  pull.statusMessage.textContent += '\nCancel requested.';
-  chatContainer.scrollTop = chatContainer.scrollHeight;
+  appendMessageText(pull.statusMessage, '\nCancel requested.');
 
   try {
     const response = await fetch('/api/pull_model/cancel', {
@@ -894,8 +951,7 @@ async function cancelCurrentPull() {
     }
   } catch (error) {
     if (currentPull === pull) {
-      pull.statusMessage.textContent += `\nCancel request failed: ${error.message}`;
-      chatContainer.scrollTop = chatContainer.scrollHeight;
+      appendMessageText(pull.statusMessage, `\nCancel request failed: ${error.message}`);
       pullModelButton.disabled = false;
     }
     return;
@@ -955,7 +1011,7 @@ async function submitPrompt(event) {
       }
       if (data.response) {
         fullText += data.response;
-        aiMessage.textContent = fullText;
+        setMessageText(aiMessage, fullText);
         chatContainer.scrollTop = chatContainer.scrollHeight;
       }
     };
@@ -979,10 +1035,10 @@ async function submitPrompt(event) {
     handleLine(buffer);
 
     if (!fullText) {
-      aiMessage.textContent = '[no response returned]';
+      setMessageText(aiMessage, '[no response returned]');
     }
   } catch (error) {
-    aiMessage.textContent = `Error: ${error.message}`;
+    setMessageText(aiMessage, `Error: ${error.message}`);
   } finally {
     promptInput.disabled = false;
     submitButton.disabled = false;

--- a/script.js
+++ b/script.js
@@ -135,15 +135,18 @@ function appendMessage(role, text) {
   const content = document.createElement('div');
   content.className = 'message-text';
 
-  const copyButton = document.createElement('button');
-  copyButton.type = 'button';
-  copyButton.className = 'message-copy-button';
-  copyButton.textContent = 'Copy';
-  copyButton.title = 'Copy message';
-  copyButton.setAttribute('aria-label', 'Copy message');
-  copyButton.addEventListener('click', () => copyMessageText(copyButton, div));
+  div.append(content);
+  if (role !== 'status') {
+    const copyButton = document.createElement('button');
+    copyButton.type = 'button';
+    copyButton.className = 'message-copy-button';
+    copyButton.textContent = 'Copy';
+    copyButton.title = 'Copy message';
+    copyButton.setAttribute('aria-label', 'Copy message');
+    copyButton.addEventListener('click', () => copyMessageText(copyButton, div));
+    div.append(copyButton);
+  }
 
-  div.append(content, copyButton);
   chatContainer.appendChild(div);
   setMessageText(div, text);
   chatContainer.scrollTop = chatContainer.scrollHeight;

--- a/script.js
+++ b/script.js
@@ -12,10 +12,23 @@ const clearFilesButton = document.getElementById('clear-files-btn');
 const pullModelButton = document.getElementById('pull-model');
 const modelDescription = document.getElementById('model-description');
 const submitButton = document.getElementById('submit-btn');
+const projectRootInput = document.getElementById('project-root-input');
+const projectQueryInput = document.getElementById('project-query-input');
+const projectFileInput = document.getElementById('project-file-input');
+const projectCommandInput = document.getElementById('project-command-input');
+const loadProjectButton = document.getElementById('load-project-btn');
+const projectContextButton = document.getElementById('project-context-btn');
+const projectSearchButton = document.getElementById('project-search-btn');
+const projectReadButton = document.getElementById('project-read-btn');
+const projectRunButton = document.getElementById('project-run-btn');
+const projectClearButton = document.getElementById('project-clear-btn');
+const projectAgentStatus = document.getElementById('project-agent-status');
+const projectAgentPreview = document.getElementById('project-agent-preview');
 
 const MAX_FILE_BYTES = 1024 * 1024;
 const MAX_FILE_CONTEXT_CHARS = 12000;
 const MAX_TOTAL_FILE_CONTEXT_CHARS = 24000;
+const MAX_PROJECT_CONTEXT_CHARS = 30000;
 const TEXT_FILE_EXTENSIONS = new Set([
   'c',
   'conf',
@@ -85,6 +98,8 @@ let modelsMap = {};
 let installedModels = new Set();
 let currentPull = null;
 let selectedFileContexts = [];
+let activeProjectRoot = '';
+let projectContextEntries = [];
 
 function stripAnsiCodes(value) {
   return String(value).replace(
@@ -330,23 +345,59 @@ function readFileAsText(file) {
   });
 }
 
+function boundedProjectContextText() {
+  let remaining = MAX_PROJECT_CONTEXT_CHARS;
+  const sections = [];
+
+  projectContextEntries.forEach((entry) => {
+    if (remaining <= 0) {
+      return;
+    }
+
+    const header = `Source: ${entry.title}`;
+    const content = String(entry.content || '');
+    const section = `${header}\n${content}`;
+    const boundedSection = section.slice(0, remaining);
+    sections.push(boundedSection);
+    remaining -= boundedSection.length;
+  });
+
+  return sections.join('\n\n---\n\n');
+}
+
 function buildFileContextPrompt(prompt) {
-  if (!selectedFileContexts.length) {
+  const sections = [];
+
+  if (projectContextEntries.length) {
+    sections.push([
+      'Use the local project context below as guardrails for this request.',
+      'Prefer project documentation and tool output over general assumptions, and cite relevant source paths when useful.',
+      '',
+      boundedProjectContextText(),
+    ].join('\n'));
+  }
+
+  if (selectedFileContexts.length) {
+    const fileSections = selectedFileContexts.map((file) => (
+      `File: ${file.name}\nSize: ${formatBytes(file.size)}\nContent:\n${file.content}`
+    ));
+    sections.push([
+      'Use the uploaded file contents below as additional context.',
+      '',
+      fileSections.join('\n\n---\n\n'),
+    ].join('\n'));
+  }
+
+  if (!sections.length) {
     return prompt;
   }
 
-  const fileSections = selectedFileContexts.map((file) => (
-    `File: ${file.name}\nSize: ${formatBytes(file.size)}\nContent:\n${file.content}`
-  ));
-
   return [
-    'Use the uploaded file contents below as context for the user request.',
-    'If the request asks for analysis, summarize the important points, call out notable issues, and answer using evidence from the files.',
-    '',
-    fileSections.join('\n\n---\n\n'),
+    ...sections,
+    'Answer the user request using the provided evidence.',
     '',
     `User request: ${prompt}`,
-  ].join('\n');
+  ].join('\n\n');
 }
 
 function setFileControls(hasFiles) {
@@ -477,6 +528,206 @@ async function fetchModelCatalog() {
     appendStatus(`Ollama model catalog unavailable, using bundled list: ${error.message}`);
     return fetchJson('models.json');
   }
+}
+
+function setProjectStatus(text) {
+  projectAgentStatus.textContent = text;
+}
+
+function setProjectBusy(isBusy) {
+  [
+    loadProjectButton,
+    projectContextButton,
+    projectSearchButton,
+    projectReadButton,
+    projectRunButton,
+    projectClearButton,
+  ].forEach((button) => {
+    button.disabled = isBusy;
+  });
+}
+
+function updateProjectPreview() {
+  if (!projectContextEntries.length) {
+    projectAgentPreview.textContent = 'No project context attached.';
+    return;
+  }
+
+  projectAgentPreview.textContent = projectContextEntries
+    .map((entry, index) => `${index + 1}. ${entry.title}\n${previewText(entry.content, 700)}`)
+    .join('\n\n');
+}
+
+function projectQuery() {
+  return projectQueryInput.value.trim() || promptInput.value.trim() || 'security architecture implementation coding guardrails';
+}
+
+async function fetchProjectJson(url, payload) {
+  return fetchJson(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}
+
+function addProjectContextEntry(title, content) {
+  projectContextEntries.push({ title, content });
+  updateProjectPreview();
+}
+
+async function loadProjectDefaults() {
+  try {
+    const defaults = await fetchJson('/api/project/defaults');
+    if (defaults.default_project && !projectRootInput.value.trim()) {
+      projectRootInput.value = defaults.default_project;
+    }
+    activeProjectRoot = projectRootInput.value.trim();
+    setProjectStatus(`Allowed roots: ${(defaults.allowed_roots || []).join(', ')}`);
+  } catch (error) {
+    setProjectStatus(`Project agent unavailable: ${error.message}`);
+  }
+  updateProjectPreview();
+}
+
+async function loadProjectSummary() {
+  const projectRoot = projectRootInput.value.trim();
+  if (!projectRoot) {
+    setProjectStatus('Enter a project root first.');
+    return;
+  }
+
+  setProjectBusy(true);
+  try {
+    const summary = await fetchProjectJson('/api/project/summary', { project_root: projectRoot });
+    activeProjectRoot = summary.project_root;
+    projectRootInput.value = activeProjectRoot;
+    setProjectStatus(`Loaded ${activeProjectRoot}: ${summary.file_count} text files, ${summary.doc_count} guardrail docs.`);
+    addProjectContextEntry(
+      `Project summary: ${activeProjectRoot}`,
+      `Text files: ${summary.file_count}\nGuardrail docs: ${summary.doc_count}\nDocs:\n${(summary.docs || []).join('\n')}`
+    );
+  } catch (error) {
+    setProjectStatus(`Project load failed: ${error.message}`);
+  } finally {
+    setProjectBusy(false);
+  }
+}
+
+async function addProjectGuardrails() {
+  const projectRoot = projectRootInput.value.trim();
+  if (!projectRoot) {
+    setProjectStatus('Enter a project root first.');
+    return;
+  }
+
+  setProjectBusy(true);
+  try {
+    const payload = await fetchProjectJson('/api/project/context', {
+      project_root: projectRoot,
+      query: projectQuery(),
+      max_chunks: 8,
+    });
+    activeProjectRoot = payload.project_root;
+    const content = (payload.chunks || []).map((chunk) => (
+      `Path: ${chunk.path}${chunk.heading ? `\nHeading: ${chunk.heading}` : ''}\n${chunk.text}`
+    )).join('\n\n---\n\n');
+    addProjectContextEntry(`Guardrails for: ${payload.query || projectQuery()}`, content || 'No matching guardrails found.');
+    setProjectStatus(`Added ${(payload.chunks || []).length} guardrail chunks from ${activeProjectRoot}.`);
+  } catch (error) {
+    setProjectStatus(`Guardrail retrieval failed: ${error.message}`);
+  } finally {
+    setProjectBusy(false);
+  }
+}
+
+async function searchProject() {
+  const query = projectQueryInput.value.trim() || promptInput.value.trim();
+  if (!query) {
+    setProjectStatus('Enter a search query first.');
+    return;
+  }
+
+  setProjectBusy(true);
+  try {
+    const payload = await fetchProjectJson('/api/project/search', {
+      project_root: projectRootInput.value.trim(),
+      query,
+      max_results: 30,
+    });
+    const content = (payload.results || []).map((result) => (
+      `${result.path}:${result.line}: ${result.text}`
+    )).join('\n');
+    addProjectContextEntry(`Search: ${query}`, content || 'No matches.');
+    setProjectStatus(`Added ${(payload.results || []).length} search results.`);
+  } catch (error) {
+    setProjectStatus(`Search failed: ${error.message}`);
+  } finally {
+    setProjectBusy(false);
+  }
+}
+
+async function readProjectFile() {
+  const path = projectFileInput.value.trim();
+  if (!path) {
+    setProjectStatus('Enter a project-relative file path first.');
+    return;
+  }
+
+  setProjectBusy(true);
+  try {
+    const payload = await fetchProjectJson('/api/project/read', {
+      project_root: projectRootInput.value.trim(),
+      path,
+    });
+    addProjectContextEntry(
+      `File: ${payload.path}`,
+      `${payload.content}${payload.truncated ? '\n\n[truncated]' : ''}`
+    );
+    setProjectStatus(`Added file context: ${payload.path}`);
+  } catch (error) {
+    setProjectStatus(`Read failed: ${error.message}`);
+  } finally {
+    setProjectBusy(false);
+  }
+}
+
+async function runProjectTool() {
+  const command = projectCommandInput.value.trim();
+  if (!command) {
+    setProjectStatus('Enter an allowed tool command first.');
+    return;
+  }
+
+  setProjectBusy(true);
+  try {
+    const payload = await fetchProjectJson('/api/project/run', {
+      project_root: projectRootInput.value.trim(),
+      command,
+    });
+    const content = [
+      `Command: ${payload.command}`,
+      `Exit code: ${payload.exit_code}${payload.timed_out ? ' (timed out)' : ''}`,
+      `Duration: ${payload.duration_ms || 0} ms`,
+      '',
+      'STDOUT:',
+      payload.stdout || '[empty]',
+      '',
+      'STDERR:',
+      payload.stderr || '[empty]',
+    ].join('\n');
+    addProjectContextEntry(`Tool output: ${command}`, content);
+    setProjectStatus(`Tool finished: ${command} (exit ${payload.exit_code})`);
+  } catch (error) {
+    setProjectStatus(`Tool failed: ${error.message}`);
+  } finally {
+    setProjectBusy(false);
+  }
+}
+
+function clearProjectContext() {
+  projectContextEntries = [];
+  updateProjectPreview();
+  setProjectStatus('Project context cleared.');
 }
 
 function addModelOption(model) {
@@ -812,6 +1063,12 @@ promptForm.addEventListener('submit', submitPrompt);
 fileInput.addEventListener('change', previewSelectedFiles);
 analyzeFilesButton.addEventListener('click', analyzeSelectedFiles);
 clearFilesButton.addEventListener('click', clearSelectedFiles);
+loadProjectButton.addEventListener('click', loadProjectSummary);
+projectContextButton.addEventListener('click', addProjectGuardrails);
+projectSearchButton.addEventListener('click', searchProject);
+projectReadButton.addEventListener('click', readProjectFile);
+projectRunButton.addEventListener('click', runProjectTool);
+projectClearButton.addEventListener('click', clearProjectContext);
 modelTypeSelect.addEventListener('change', () => {
   currentModelType = modelTypeSelect.value;
   currentSize = '';
@@ -831,5 +1088,6 @@ sizeSelect.addEventListener('change', () => {
 });
 window.addEventListener('DOMContentLoaded', () => {
   populateModelTypeSelect();
+  loadProjectDefaults();
   fetchModels();
 });

--- a/script.js
+++ b/script.js
@@ -55,7 +55,6 @@ const MODEL_TYPE_OPTIONS = [
   { value: 'thinking', label: 'Thinking' },
   { value: 'vision', label: 'Vision' },
   { value: 'audio', label: 'Audio' },
-  { value: 'cloud', label: 'Cloud' },
   { value: 'embedding', label: 'Embedding' },
 ];
 const CODE_DEVELOPMENT_TERMS = [
@@ -283,27 +282,15 @@ function isModelInstalled(modelName, size = '') {
   return installedModels.has(modelReference) || (!size && installedModels.has(`${modelName}:latest`));
 }
 
-function isCloudOnlyModel(modelName) {
-  const model = modelsMap[modelName];
-  if (!model || isModelInstalled(modelName)) {
-    return false;
-  }
-
-  return modelCapabilities(model).includes('cloud') && getModelSizes(modelName).length === 0;
-}
-
 function updateSelectedModelControls() {
   const hasModels = modelSelect.options.length > 0;
-  const cloudOnly = isCloudOnlyModel(currentModel);
   modelSelect.disabled = Boolean(currentPull) || !hasModels;
 
   if (!currentPull) {
-    pullModelButton.disabled = !hasModels || cloudOnly;
-    pullModelButton.title = cloudOnly ? 'Cloud-only catalog entry; no local Ollama manifest is available to pull.' : '';
+    pullModelButton.disabled = !hasModels;
   }
 
-  submitButton.disabled = !hasModels || cloudOnly;
-  submitButton.title = cloudOnly ? 'Cloud-only catalog entry; local chat generation is not available.' : '';
+  submitButton.disabled = !hasModels;
 }
 
 function fileExtension(fileName) {
@@ -405,7 +392,6 @@ function parseGenerateLine(line) {
 function populateSizeSelect(modelName) {
   const sizes = getModelSizes(modelName);
   const preferredSize = sizes.includes(currentSize) ? currentSize : sizes[0] || '';
-  const cloudOnly = isCloudOnlyModel(modelName);
 
   sizeSelect.replaceChildren();
   if (sizes.length) {
@@ -418,7 +404,7 @@ function populateSizeSelect(modelName) {
   } else {
     const option = document.createElement('option');
     option.value = '';
-    option.textContent = cloudOnly ? 'cloud only' : 'default';
+    option.textContent = 'default';
     sizeSelect.appendChild(option);
   }
 
@@ -447,20 +433,14 @@ function setModelDescription(modelName) {
   }
   if (Array.isArray(model.sizes) && model.sizes.length) {
     details.push(`Sizes: ${model.sizes.join(', ')}`);
-  } else if (isCloudOnlyModel(modelName)) {
-    details.push('Local pull: unavailable for this cloud-only catalog entry');
   }
 
   const installed = document.createElement('div');
   const selectedSize = sizeSelect.value;
   const modelReference = selectedModelReference();
-  if (isCloudOnlyModel(modelName)) {
-    installed.textContent = 'Local status: no local Ollama manifest is available';
-  } else {
-    installed.textContent = isModelInstalled(modelName, selectedSize)
-      ? 'Local status: installed'
-      : `Local status: ${modelReference} not detected locally`;
-  }
+  installed.textContent = isModelInstalled(modelName, selectedSize)
+    ? 'Local status: installed'
+    : `Local status: ${modelReference} not detected locally`;
 
   const detailNodes = details.map((detail) => {
     const node = document.createElement('div');
@@ -584,10 +564,6 @@ function pullSelectedModel() {
 
   const modelName = modelSelect.value;
   const model = selectedModelReference();
-  if (isCloudOnlyModel(modelName)) {
-    appendStatus(`${modelName} is listed as a cloud-only Ollama catalog entry and cannot be pulled into the local Ollama runtime.`);
-    return;
-  }
   if (!model) {
     appendStatus('No model selected.');
     return;
@@ -684,10 +660,6 @@ async function submitPrompt(event) {
 
   const prompt = promptInput.value.trim();
   const model = selectedModelReference();
-  if (isCloudOnlyModel(currentModel)) {
-    appendStatus(`${currentModel} is a cloud-only catalog entry and is not available through this local Ollama chat proxy.`);
-    return;
-  }
   if (!prompt || !model) {
     return;
   }

--- a/scripts/pull_model.py
+++ b/scripts/pull_model.py
@@ -33,7 +33,7 @@ MODEL_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,127}$")
 PULL_ID_RE = re.compile(r"^[A-Za-z0-9_.:-]{1,80}$")
 STATIC_ASSET_EXTENSIONS = {".css", ".html", ".ico", ".js", ".json"}
 UPDATED_AGE_RE = re.compile(r"(\d+(?:\.\d+)?)\s*(minute|hour|day|week|month|year)s?\s+ago")
-MODEL_CAPABILITY_TAGS = {"audio", "cloud", "embedding", "thinking", "tools", "vision"}
+MODEL_CAPABILITY_TAGS = {"audio", "embedding", "thinking", "tools", "vision"}
 catalog_cache: dict[str, Any] = {"expires_at": 0.0, "models": []}
 active_pulls: dict[str, requests.Response] = {}
 cancelled_pulls: set[str] = set()
@@ -131,9 +131,14 @@ class OllamaLibraryParser(HTMLParser):
 
         name = str(self._current.get("name", "")).strip()
         if name and name not in self._seen_names:
-            self._seen_names.add(name)
             capabilities = self._current.get("capabilities", [])
+            sizes = self._current.get("sizes", [])
             badges = [str(badge).strip().lower() for badge in self._current.get("badges", [])]
+            if "cloud" in badges and not sizes:
+                self._current = None
+                return
+
+            self._seen_names.add(name)
             self._current["capabilities"] = [
                 *capabilities,
                 *(badge for badge in badges if badge in MODEL_CAPABILITY_TAGS and badge not in capabilities),

--- a/scripts/pull_model.py
+++ b/scripts/pull_model.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
+import subprocess
 import time
 from html.parser import HTMLParser
 from pathlib import Path
@@ -34,6 +36,64 @@ PULL_ID_RE = re.compile(r"^[A-Za-z0-9_.:-]{1,80}$")
 STATIC_ASSET_EXTENSIONS = {".css", ".html", ".ico", ".js", ".json"}
 UPDATED_AGE_RE = re.compile(r"(\d+(?:\.\d+)?)\s*(minute|hour|day|week|month|year)s?\s+ago")
 MODEL_CAPABILITY_TAGS = {"audio", "embedding", "thinking", "tools", "vision"}
+DEFAULT_PROJECT_ROOT = Path("/home/foo/Workspace/OSMAP")
+PROJECT_ROOTS_ENV = os.environ.get("OLLAMA_WEBUI_PROJECT_ROOTS", str(Path.home() / "Workspace"))
+PROJECT_ROOTS = [Path(part).expanduser().resolve() for part in PROJECT_ROOTS_ENV.split(os.pathsep) if part.strip()]
+PROJECT_EXCLUDED_DIRS = {
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    "__pycache__",
+    "dist",
+    "node_modules",
+    "target",
+    "vendor",
+}
+PROJECT_TEXT_EXTENSIONS = {
+    ".c",
+    ".conf",
+    ".cpp",
+    ".cs",
+    ".css",
+    ".csv",
+    ".go",
+    ".h",
+    ".html",
+    ".ini",
+    ".java",
+    ".js",
+    ".json",
+    ".jsx",
+    ".lock",
+    ".md",
+    ".php",
+    ".py",
+    ".rb",
+    ".rs",
+    ".sh",
+    ".sql",
+    ".toml",
+    ".ts",
+    ".tsx",
+    ".txt",
+    ".xml",
+    ".yaml",
+    ".yml",
+}
+PROJECT_DOC_EXTENSIONS = {".md", ".txt"}
+MAX_PROJECT_FILE_BYTES = 256 * 1024
+MAX_PROJECT_SEARCH_FILE_BYTES = 512 * 1024
+MAX_PROJECT_CONTEXT_CHARS = 18000
+MAX_PROJECT_CHUNK_CHARS = 2200
+MAX_PROJECT_COMMAND_OUTPUT_CHARS = 30000
+PROJECT_COMMAND_TIMEOUT_SECONDS = 120
+ALLOWED_CARGO_SUBCOMMANDS = {"build", "check", "clippy", "fmt", "metadata", "test"}
+ALLOWED_GIT_SUBCOMMANDS = {"diff", "log", "show", "status"}
+ALLOWED_PYTHON_MODULES = {"compileall", "mypy", "py_compile", "pytest", "ruff", "unittest"}
+ALLOWED_DIRECT_COMMANDS = {"cargo", "git", "mypy", "pytest", "ruff", "rustc"}
 catalog_cache: dict[str, Any] = {"expires_at": 0.0, "models": []}
 active_pulls: dict[str, requests.Response] = {}
 cancelled_pulls: set[str] = set()
@@ -320,6 +380,252 @@ def proxy_ollama_json(path: str) -> tuple[dict[str, Any], int]:
     return payload, response.status_code
 
 
+def is_relative_to(path: Path, parent: Path) -> bool:
+    """Return True when path is under parent."""
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+
+    return True
+
+
+def allowed_project_root(path_value: str | None) -> Path | None:
+    """Resolve a user-supplied project path if it is inside an allowed root."""
+    if not path_value:
+        return None
+
+    try:
+        project_root = Path(path_value).expanduser().resolve()
+    except (OSError, RuntimeError):
+        return None
+
+    if not project_root.is_dir():
+        return None
+
+    return project_root if any(is_relative_to(project_root, root) for root in PROJECT_ROOTS) else None
+
+
+def project_file_path(project_root: Path, relative_path: str | None) -> Path | None:
+    """Resolve a relative file path under a validated project root."""
+    if not relative_path:
+        return None
+
+    try:
+        file_path = (project_root / relative_path).resolve()
+    except (OSError, RuntimeError):
+        return None
+
+    if not is_relative_to(file_path, project_root) or not file_path.is_file():
+        return None
+
+    return file_path
+
+
+def is_project_text_file(path: Path) -> bool:
+    """Return True for project files that are safe and useful to read as text."""
+    return path.suffix.lower() in PROJECT_TEXT_EXTENSIONS or path.name in {"Dockerfile", "Makefile"}
+
+
+def should_skip_project_dir(path: Path) -> bool:
+    """Return True for directories that should not be searched or read."""
+    return path.name in PROJECT_EXCLUDED_DIRS or path.name.startswith(".") and path.name not in {".github"}
+
+
+def iter_project_files(project_root: Path, docs_only: bool = False) -> Iterator[Path]:
+    """Yield bounded text files under a project root."""
+    for directory, dirnames, filenames in os.walk(project_root):
+        directory_path = Path(directory)
+        dirnames[:] = [name for name in dirnames if not should_skip_project_dir(directory_path / name)]
+
+        for filename in filenames:
+            path = directory_path / filename
+            if not is_project_text_file(path):
+                continue
+            if docs_only:
+                relative = path.relative_to(project_root)
+                is_doc_file = relative.parts and relative.parts[0] == "docs" and path.suffix.lower() in PROJECT_DOC_EXTENSIONS
+                is_root_doc = len(relative.parts) == 1 and path.name in {"README.md", "SECURITY.md", "CONTRIBUTING.md"}
+                if not is_doc_file and not is_root_doc:
+                    continue
+            try:
+                if path.stat().st_size > MAX_PROJECT_SEARCH_FILE_BYTES:
+                    continue
+            except OSError:
+                continue
+            yield path
+
+
+def read_project_text(path: Path, max_chars: int = MAX_PROJECT_FILE_BYTES) -> tuple[str, bool]:
+    """Read project text with replacement and a truncation flag."""
+    raw = path.read_bytes()
+    truncated = len(raw) > max_chars
+    text = raw[:max_chars].decode("utf-8", errors="replace")
+    return text, truncated
+
+
+def query_terms(query: str) -> list[str]:
+    """Return useful lowercase search terms."""
+    stop_words = {
+        "a",
+        "an",
+        "and",
+        "are",
+        "as",
+        "for",
+        "in",
+        "is",
+        "of",
+        "on",
+        "or",
+        "the",
+        "to",
+        "with",
+    }
+    terms = re.findall(r"[a-zA-Z0-9_.:-]+", query.lower())
+    return [term for term in terms if len(term) > 2 and term not in stop_words]
+
+
+def split_context_chunks(project_root: Path, path: Path, text: str) -> list[dict[str, Any]]:
+    """Split text into heading-aware chunks."""
+    relative = str(path.relative_to(project_root))
+    chunks: list[dict[str, Any]] = []
+    current_heading = ""
+    current_lines: list[str] = []
+
+    def flush() -> None:
+        nonlocal current_lines
+        content = "\n".join(current_lines).strip()
+        if not content:
+            current_lines = []
+            return
+        while len(content) > MAX_PROJECT_CHUNK_CHARS:
+            chunks.append({"path": relative, "heading": current_heading, "text": content[:MAX_PROJECT_CHUNK_CHARS]})
+            content = content[MAX_PROJECT_CHUNK_CHARS:]
+        chunks.append({"path": relative, "heading": current_heading, "text": content})
+        current_lines = []
+
+    for line in text.splitlines():
+        if path.suffix.lower() == ".md" and line.startswith("#"):
+            flush()
+            current_heading = line.strip("# ").strip()
+        current_lines.append(line)
+        if sum(len(part) + 1 for part in current_lines) >= MAX_PROJECT_CHUNK_CHARS:
+            flush()
+
+    flush()
+    return chunks
+
+
+def score_context_chunk(chunk: dict[str, Any], terms: list[str]) -> int:
+    """Score a context chunk using simple local lexical matching."""
+    if not terms:
+        return 1
+
+    path = str(chunk.get("path", "")).lower()
+    heading = str(chunk.get("heading", "")).lower()
+    text = str(chunk.get("text", "")).lower()
+    score = 0
+    for term in terms:
+        score += path.count(term) * 5
+        score += heading.count(term) * 4
+        score += text.count(term)
+    return score
+
+
+def project_context(project_root: Path, query: str, max_chunks: int = 8) -> list[dict[str, Any]]:
+    """Return the most relevant project guardrail chunks."""
+    terms = query_terms(query or "security architecture implementation guardrails coding requirements")
+    scored: list[tuple[int, dict[str, Any]]] = []
+    for path in iter_project_files(project_root, docs_only=True):
+        try:
+            text, _ = read_project_text(path, MAX_PROJECT_SEARCH_FILE_BYTES)
+        except OSError:
+            continue
+        for chunk in split_context_chunks(project_root, path, text):
+            score = score_context_chunk(chunk, terms)
+            if score > 0:
+                scored.append((score, chunk))
+
+    scored.sort(key=lambda item: (-item[0], str(item[1].get("path", "")), str(item[1].get("heading", ""))))
+    chunks = [chunk | {"score": score} for score, chunk in scored[:max_chunks]]
+    total_chars = 0
+    bounded_chunks = []
+    for chunk in chunks:
+        text = str(chunk.get("text", ""))
+        remaining = MAX_PROJECT_CONTEXT_CHARS - total_chars
+        if remaining <= 0:
+            break
+        if len(text) > remaining:
+            chunk = {**chunk, "text": text[:remaining], "truncated": True}
+        bounded_chunks.append(chunk)
+        total_chars += len(str(chunk.get("text", "")))
+    return bounded_chunks
+
+
+def search_project(project_root: Path, query: str, max_results: int = 30) -> list[dict[str, Any]]:
+    """Search project text files for query terms."""
+    terms = query_terms(query)
+    if not terms:
+        return []
+
+    results: list[dict[str, Any]] = []
+    for path in iter_project_files(project_root):
+        try:
+            text, _ = read_project_text(path, MAX_PROJECT_SEARCH_FILE_BYTES)
+        except OSError:
+            continue
+        relative = str(path.relative_to(project_root))
+        for number, line in enumerate(text.splitlines(), start=1):
+            lowered = line.lower()
+            if all(term in lowered for term in terms):
+                results.append({"path": relative, "line": number, "text": line.strip()[:300]})
+                if len(results) >= max_results:
+                    return results
+    return results
+
+
+def validate_project_command(command: str) -> tuple[list[str] | None, str | None]:
+    """Return argv for an allowed local development command."""
+    try:
+        argv = shlex.split(command)
+    except ValueError as exc:
+        return None, f"invalid command: {exc}"
+
+    if not argv:
+        return None, "missing command"
+
+    executable = Path(argv[0]).name
+    if executable in {"python", "python3"}:
+        if len(argv) < 3 or argv[1] != "-m" or argv[2] not in ALLOWED_PYTHON_MODULES:
+            return None, "python commands must use -m with an allowed module"
+        return [executable, *argv[1:]], None
+
+    if executable == "cargo":
+        if len(argv) < 2 or argv[1] not in ALLOWED_CARGO_SUBCOMMANDS:
+            return None, "cargo command must use an allowed subcommand"
+        return [executable, *argv[1:]], None
+
+    if executable == "git":
+        if len(argv) < 2 or argv[1] not in ALLOWED_GIT_SUBCOMMANDS:
+            return None, "git command must be read-only"
+        return [executable, *argv[1:]], None
+
+    if executable not in ALLOWED_DIRECT_COMMANDS:
+        return None, f"command is not allowed: {executable}"
+
+    return [executable, *argv[1:]], None
+
+
+def project_command_env() -> dict[str, str]:
+    """Return a command environment with common user tool directories on PATH."""
+    env = os.environ.copy()
+    extra_paths = [str(Path.home() / ".cargo" / "bin"), str(Path.home() / ".local" / "bin")]
+    existing_path = env.get("PATH", "")
+    env["PATH"] = os.pathsep.join([*extra_paths, existing_path])
+    return env
+
+
 @app.get("/")
 def serve_index() -> Response:
     """Serve the main Web UI."""
@@ -350,6 +656,146 @@ def api_tags() -> tuple[Response, int]:
 def api_models() -> Response:
     """Return the pullable Ollama model catalog."""
     return jsonify(model_catalog())
+
+
+@app.get("/api/project/defaults")
+def api_project_defaults() -> Response:
+    """Return project-agent defaults and allowed tool names."""
+    default_root = DEFAULT_PROJECT_ROOT if DEFAULT_PROJECT_ROOT.is_dir() else (PROJECT_ROOTS[0] if PROJECT_ROOTS else Path.home())
+    return jsonify(
+        {
+            "allowed_roots": [str(root) for root in PROJECT_ROOTS],
+            "default_project": str(default_root),
+            "allowed_tools": {
+                "cargo": sorted(ALLOWED_CARGO_SUBCOMMANDS),
+                "git": sorted(ALLOWED_GIT_SUBCOMMANDS),
+                "python_modules": sorted(ALLOWED_PYTHON_MODULES),
+                "direct": sorted(ALLOWED_DIRECT_COMMANDS - {"cargo", "git"}),
+            },
+        }
+    )
+
+
+@app.post("/api/project/summary")
+def api_project_summary() -> tuple[Response, int]:
+    """Return a bounded project summary for the Project Agent panel."""
+    body = request.get_json(silent=True) or {}
+    project_root = allowed_project_root(str(body.get("project_root", "")))
+    if project_root is None:
+        return jsonify({"error": "project_root must be an existing directory under an allowed workspace root"}), 400
+
+    docs = []
+    file_count = 0
+    doc_count = 0
+    for path in iter_project_files(project_root):
+        file_count += 1
+        relative = path.relative_to(project_root)
+        if relative.parts and (relative.parts[0] == "docs" or path.name in {"README.md", "SECURITY.md", "CONTRIBUTING.md"}):
+            doc_count += 1
+            if len(docs) < 40:
+                docs.append(str(relative))
+
+    return jsonify({"project_root": str(project_root), "file_count": file_count, "doc_count": doc_count, "docs": docs}), 200
+
+
+@app.post("/api/project/context")
+def api_project_context() -> tuple[Response, int]:
+    """Return relevant guardrail context from project documentation."""
+    body = request.get_json(silent=True) or {}
+    project_root = allowed_project_root(str(body.get("project_root", "")))
+    if project_root is None:
+        return jsonify({"error": "project_root must be an existing directory under an allowed workspace root"}), 400
+
+    query = str(body.get("query", "")).strip()
+    max_chunks = min(max(int(body.get("max_chunks", 8) or 8), 1), 12)
+    chunks = project_context(project_root, query, max_chunks=max_chunks)
+    return jsonify({"project_root": str(project_root), "query": query, "chunks": chunks}), 200
+
+
+@app.post("/api/project/search")
+def api_project_search() -> tuple[Response, int]:
+    """Search text files inside a validated project root."""
+    body = request.get_json(silent=True) or {}
+    project_root = allowed_project_root(str(body.get("project_root", "")))
+    if project_root is None:
+        return jsonify({"error": "project_root must be an existing directory under an allowed workspace root"}), 400
+
+    query = str(body.get("query", "")).strip()
+    if not query:
+        return jsonify({"error": "missing query"}), 400
+
+    max_results = min(max(int(body.get("max_results", 30) or 30), 1), 80)
+    return jsonify({"project_root": str(project_root), "query": query, "results": search_project(project_root, query, max_results)}), 200
+
+
+@app.post("/api/project/read")
+def api_project_read() -> tuple[Response, int]:
+    """Read one bounded text file under a validated project root."""
+    body = request.get_json(silent=True) or {}
+    project_root = allowed_project_root(str(body.get("project_root", "")))
+    if project_root is None:
+        return jsonify({"error": "project_root must be an existing directory under an allowed workspace root"}), 400
+
+    path = project_file_path(project_root, str(body.get("path", "")))
+    if path is None or not is_project_text_file(path):
+        return jsonify({"error": "path must be a readable text file under the project root"}), 400
+
+    try:
+        text, truncated = read_project_text(path)
+    except OSError as exc:
+        return jsonify({"error": f"unable to read file: {exc}"}), 400
+
+    return jsonify({"path": str(path.relative_to(project_root)), "content": text, "truncated": truncated}), 200
+
+
+@app.post("/api/project/run")
+def api_project_run() -> tuple[Response, int]:
+    """Run a bounded allowlisted development command in a project root."""
+    body = request.get_json(silent=True) or {}
+    project_root = allowed_project_root(str(body.get("project_root", "")))
+    if project_root is None:
+        return jsonify({"error": "project_root must be an existing directory under an allowed workspace root"}), 400
+
+    command = str(body.get("command", "")).strip()
+    argv, error = validate_project_command(command)
+    if argv is None:
+        return jsonify({"error": error or "command is not allowed"}), 400
+
+    started_at = time.monotonic()
+    try:
+        completed = subprocess.run(
+            argv,
+            cwd=project_root,
+            env=project_command_env(),
+            capture_output=True,
+            text=True,
+            timeout=PROJECT_COMMAND_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except FileNotFoundError:
+        return jsonify({"error": f"command not found on this system: {argv[0]}"}), 400
+    except subprocess.TimeoutExpired as exc:
+        stdout = (exc.stdout or "")[-MAX_PROJECT_COMMAND_OUTPUT_CHARS:]
+        stderr = (exc.stderr or "")[-MAX_PROJECT_COMMAND_OUTPUT_CHARS:]
+        return jsonify({"command": command, "exit_code": None, "timed_out": True, "stdout": stdout, "stderr": stderr}), 200
+
+    duration_ms = round((time.monotonic() - started_at) * 1000)
+    stdout = completed.stdout[-MAX_PROJECT_COMMAND_OUTPUT_CHARS:]
+    stderr = completed.stderr[-MAX_PROJECT_COMMAND_OUTPUT_CHARS:]
+    return (
+        jsonify(
+            {
+                "command": command,
+                "argv": argv,
+                "exit_code": completed.returncode,
+                "duration_ms": duration_ms,
+                "stdout": stdout,
+                "stderr": stderr,
+                "timed_out": False,
+            }
+        ),
+        200,
+    )
 
 
 @app.post("/api/generate")

--- a/scripts/pull_model.py
+++ b/scripts/pull_model.py
@@ -32,6 +32,8 @@ OLLAMA_LIBRARY_URL = os.environ.get("OLLAMA_LIBRARY_URL", "https://ollama.com/li
 MODEL_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,127}$")
 PULL_ID_RE = re.compile(r"^[A-Za-z0-9_.:-]{1,80}$")
 STATIC_ASSET_EXTENSIONS = {".css", ".html", ".ico", ".js", ".json"}
+UPDATED_AGE_RE = re.compile(r"(\d+(?:\.\d+)?)\s*(minute|hour|day|week|month|year)s?\s+ago")
+MODEL_CAPABILITY_TAGS = {"audio", "cloud", "embedding", "thinking", "tools", "vision"}
 catalog_cache: dict[str, Any] = {"expires_at": 0.0, "models": []}
 active_pulls: dict[str, requests.Response] = {}
 cancelled_pulls: set[str] = set()
@@ -84,6 +86,8 @@ class OllamaLibraryParser(HTMLParser):
         self._depth += 1
         if tag == "div" and "x-test-model-title" in attrs_map:
             self._current["name"] = attrs_map.get("title", "").strip()
+        elif tag == "span" and "x-test-search-response-title" in attrs_map:
+            self._start_capture("name")
         elif tag == "p" and not self._current["description"]:
             self._start_capture("description")
         elif tag == "span" and "x-test-capability" in attrs_map:
@@ -126,13 +130,14 @@ class OllamaLibraryParser(HTMLParser):
             return
 
         name = str(self._current.get("name", "")).strip()
-        capabilities = self._current.get("capabilities", [])
-        sizes = self._current.get("sizes", [])
-        badges = [str(badge).lower() for badge in self._current.get("badges", [])]
-        is_embedding_only = capabilities == ["embedding"]
-        is_cloud_only = "cloud" in badges and not sizes
-        if name and name not in self._seen_names and not is_embedding_only and not is_cloud_only:
+        if name and name not in self._seen_names:
             self._seen_names.add(name)
+            capabilities = self._current.get("capabilities", [])
+            badges = [str(badge).strip().lower() for badge in self._current.get("badges", [])]
+            self._current["capabilities"] = [
+                *capabilities,
+                *(badge for badge in badges if badge in MODEL_CAPABILITY_TAGS and badge not in capabilities),
+            ]
             self._current.pop("badges", None)
             self.models.append(self._current)
 
@@ -196,6 +201,37 @@ def load_bundled_model_catalog() -> list[dict[str, Any]]:
     return [model for model in payload if isinstance(model, dict) and model.get("name")]
 
 
+def updated_age_sort_value(model: dict[str, Any]) -> float:
+    """Return an approximate age in days for Ollama's relative updated label."""
+    updated = str(model.get("updated", "")).strip().lower()
+    if not updated or updated == "local":
+        return float("inf")
+    if updated == "today":
+        return 0
+    if updated == "yesterday":
+        return 1
+
+    match = UPDATED_AGE_RE.search(updated)
+    if match is None:
+        return float("inf")
+
+    amount = float(match.group(1))
+    unit_days = {
+        "minute": 1 / 1440,
+        "hour": 1 / 24,
+        "day": 1,
+        "week": 7,
+        "month": 30,
+        "year": 365,
+    }
+    return amount * unit_days[match.group(2)]
+
+
+def sort_models_by_updated(models: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Sort models newest-first using the timestamp available from Ollama."""
+    return sorted(models, key=lambda model: (updated_age_sort_value(model), str(model.get("name", ""))))
+
+
 def fetch_ollama_library_catalog() -> list[dict[str, Any]]:
     """Fetch and parse the current public Ollama model library."""
     response = requests.get(
@@ -225,6 +261,7 @@ def model_catalog() -> list[dict[str, Any]]:
     if not models:
         models = load_bundled_model_catalog()
 
+    models = sort_models_by_updated(models)
     catalog_cache["models"] = models
     catalog_cache["expires_at"] = now + CATALOG_CACHE_SECONDS
     return models

--- a/style.css
+++ b/style.css
@@ -89,6 +89,51 @@ main#chat-container {
   border-top: 1px solid #444;
 }
 
+#project-agent-area {
+  padding: 0.6rem 1rem;
+  background: #242424;
+  border-top: 1px solid #444;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.project-agent-grid {
+  display: grid;
+  grid-template-columns: minmax(12rem, 1fr) auto minmax(12rem, 1fr) auto minmax(10rem, 1fr) auto minmax(10rem, 1fr) auto auto auto;
+  gap: 0.5rem;
+  align-items: end;
+}
+
+.project-agent-grid label {
+  color: #d6d6d6;
+  display: flex;
+  flex-direction: column;
+  font-size: 0.75rem;
+  gap: 0.25rem;
+}
+
+#project-agent-status {
+  color: #d6d6d6;
+  font-size: 0.82rem;
+  min-height: 1rem;
+}
+
+#project-agent-preview {
+  background: #1e1e1e;
+  border: 1px solid #444;
+  border-radius: 5px;
+  color: #ccc;
+  font-family: ui-monospace, SFMono-Regular, Consolas, 'Liberation Mono', monospace;
+  font-size: 0.78rem;
+  line-height: 1.35;
+  margin: 0;
+  max-height: 120px;
+  overflow: auto;
+  padding: 0.5rem;
+  white-space: pre-wrap;
+}
+
 #file-input {
   display: none;
 }
@@ -132,6 +177,10 @@ footer {
 }
 
 #prompt-input,
+#project-root-input,
+#project-query-input,
+#project-file-input,
+#project-command-input,
 #model-type-select,
 #model-select,
 #size-select {
@@ -161,6 +210,12 @@ button:disabled,
 #model-type-select:disabled,
 #model-select:disabled,
 #size-select:disabled,
+#load-project-btn:disabled,
+#project-context-btn:disabled,
+#project-search-btn:disabled,
+#project-read-btn:disabled,
+#project-run-btn:disabled,
+#project-clear-btn:disabled,
 #analyze-files-btn:disabled,
 #clear-files-btn:disabled {
   cursor: not-allowed;
@@ -173,6 +228,7 @@ button:disabled,
   }
 
   .model-controls,
+  .project-agent-grid,
   .upload-controls,
   #prompt-form {
     flex-direction: column;
@@ -180,6 +236,10 @@ button:disabled,
   }
 
   .upload-controls {
+    display: flex;
+  }
+
+  .project-agent-grid {
     display: flex;
   }
 

--- a/style.css
+++ b/style.css
@@ -132,6 +132,7 @@ footer {
 }
 
 #prompt-input,
+#model-type-select,
 #model-select,
 #size-select {
   padding: 0.5rem;
@@ -157,6 +158,7 @@ button {
 
 button:disabled,
 #prompt-input:disabled,
+#model-type-select:disabled,
 #model-select:disabled,
 #size-select:disabled,
 #analyze-files-btn:disabled,

--- a/style.css
+++ b/style.css
@@ -54,9 +54,35 @@ main#chat-container {
 .message {
   max-width: 80%;
   padding: 0.75rem;
+  padding-right: 4rem;
   border-radius: 10px;
+  position: relative;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
+}
+
+.message-text {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.message-copy-button {
+  background: #1e1e1e;
+  border: 1px solid #666;
+  border-radius: 4px;
+  color: #ffff66;
+  font-size: 0.72rem;
+  line-height: 1;
+  opacity: 0.75;
+  padding: 0.3rem 0.45rem;
+  position: absolute;
+  right: 0.4rem;
+  top: 0.4rem;
+}
+
+.message-copy-button:focus,
+.message-copy-button:hover {
+  opacity: 1;
 }
 
 .message.user {

--- a/style.css
+++ b/style.css
@@ -54,7 +54,7 @@ main#chat-container {
 .message {
   max-width: 80%;
   padding: 0.75rem;
-  padding-right: 4rem;
+  padding-bottom: 2rem;
   border-radius: 10px;
   position: relative;
   white-space: pre-wrap;
@@ -76,8 +76,8 @@ main#chat-container {
   opacity: 0.75;
   padding: 0.3rem 0.45rem;
   position: absolute;
+  bottom: 0.4rem;
   right: 0.4rem;
-  top: 0.4rem;
 }
 
 .message-copy-button:focus,


### PR DESCRIPTION
## Summary
- add a model type filter with `Any`, `Code Development`, and Ollama capability types
- sort the model selector newest-first by Ollama catalog updated time
- remove cloud-only catalog entries from local pull/display workflows because they cannot be pulled locally
- add scoped Project Agent controls for local project summaries, guardrail retrieval, file search/read, and allowlisted development tool execution
- add copy controls for user and assistant chat messages only, with no copy control on pull/status boxes
- document this project as an intentionally insecure local lab target, similar in purpose to OWASP Juice Shop, for use by the AI Browser Security Test Suite

## Verification
- `.venv/bin/python -m py_compile scripts/pull_model.py scripts/deploy_full_ollama_ui.py`
- `.venv/bin/python -m json.tool models.json >/dev/null`
- browser smoke tests verified model type filters, Project Agent flows, copy-control placement, and pull/status behavior

## Merge status
- Latest branch commit: `df1749b`
- This PR is still blocked by repository rules requiring one approving review from a writer and the required status context `Security CI / python-checks`.
- Direct fast-forward push of this branch to `main` was also rejected by the same rules.