### PR TITLE
add browser-safe target scenario contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The expected use case is local defensive research, browser-AI testing, and contr
 - Cancel button for an active model pull
 - Text-like file analysis through prompt context
 - Project Agent panel for scoped local project guardrails, file search/read, and allowlisted development tool execution
+- Browser-Safe AI target scenario contract for toolkit traceability
 - Same-origin Flask proxy to avoid direct browser CORS issues
 
 ## Requirements
@@ -123,6 +124,52 @@ While a pull is active, the Web UI changes the pull button to `Cancel Pull`. Can
 Use `Upload File(s)` to select text-like files such as Markdown, plain text, code, CSV, JSON, XML, YAML, or logs. The browser reads supported files locally and adds their contents to the next prompt sent to Ollama.
 
 Click `Analyze Files` to send a default analysis request, or type your own question and press `Send`. Large files are skipped or truncated before being added to the prompt so local models are not overloaded.
+
+
+## Browser-Safe AI Target Scenario Contract
+
+This intentionally vulnerable app now publishes a controlled target scenario contract for the Browser-Safe AI Systems toolkit.
+
+Machine-readable contract:
+
+```text
+docs/target-scenario-contract-v0.2.json
+```
+
+Human-readable contract:
+
+```text
+docs/target-scenario-contract-v0.2.md
+```
+
+Local helper endpoint:
+
+```text
+http://127.0.0.1:11435/api/browser-safe/target-contract
+```
+
+The contract defines which local lab surfaces are active, which tests are allowed, which tests are out of scope, which evidence artifacts are expected, and which article-series parts the scenario supports.
+
+Current scenario ids:
+
+```text
+chat.basic_prompt
+file_upload.text_context
+project_agent.guardrail_context
+project_agent.search
+project_agent.read_file
+project_agent.run_tool
+model.catalog_filter
+```
+
+Validate the contract before treating it as a toolkit target source:
+
+```bash
+cd /home/foo/Workspace/ollama-webui
+python scripts/validate_target_contract.py
+```
+
+The contract does not make this application safer. It makes the deliberately weak lab target more explicit and prevents the toolkit from claiming coverage that the target has not declared.
 
 ## Project Agent
 

--- a/docs/target-scenario-contract-v0.2.json
+++ b/docs/target-scenario-contract-v0.2.json
@@ -1,0 +1,307 @@
+{
+  "schema_version": "browser-safe-ai-target-contract/v0.2",
+  "target": {
+    "name": "ollama-webui",
+    "role": "intentionally vulnerable local browser-based AI lab target",
+    "repository": "https://github.com/unattributed/ollama-webui",
+    "local_base_url": "http://127.0.0.1:11435",
+    "allowed_environment": "local lab only",
+    "production_safe": false
+  },
+  "safety_boundaries": {
+    "authorized_scope": [
+      "local loopback browser testing",
+      "local files and repositories owned by the operator",
+      "safe synthetic prompts, local fixtures, and intentionally vulnerable app behavior"
+    ],
+    "out_of_scope": [
+      "third-party systems",
+      "credential theft",
+      "persistence",
+      "evasion",
+      "public internet exposure",
+      "destructive tool execution",
+      "production secrets"
+    ],
+    "operator_requirements": [
+      "bind only to localhost",
+      "use only local lab repositories or synthetic fixtures",
+      "do not use with production credentials",
+      "review generated artifacts before publishing"
+    ]
+  },
+  "global_limits": {
+    "max_file_bytes": 1048576,
+    "max_file_context_chars": 12000,
+    "max_total_file_context_chars": 24000,
+    "max_project_context_chars": 30000,
+    "project_helper_max_file_bytes": 262144,
+    "project_helper_max_search_file_bytes": 524288,
+    "project_helper_max_command_output_chars": 30000,
+    "project_helper_command_timeout_seconds": 120
+  },
+  "scenarios": [
+    {
+      "id": "chat.basic_prompt",
+      "status": "active",
+      "ui_surface": "chat form",
+      "endpoint": "/api/generate",
+      "evidence_class": "browser_chat_generation",
+      "allowed_tests": [
+        "safe prompt rendering",
+        "response capture",
+        "copy-button placement",
+        "model and tag selection traceability"
+      ],
+      "disallowed_tests": [
+        "credential collection",
+        "unauthorized network scanning",
+        "remote target exploitation"
+      ],
+      "expected_artifacts": [
+        "screenshot",
+        "dom_snapshot",
+        "network_log",
+        "evidence_record"
+      ],
+      "article_parts": [
+        "Part 08",
+        "Part 09"
+      ],
+      "toolkit_mapping": {
+        "current": [
+          "safe prompt evidence capture"
+        ],
+        "planned": [
+          "structured browser chat scenario contract validation"
+        ]
+      }
+    },
+    {
+      "id": "file_upload.text_context",
+      "status": "active",
+      "ui_surface": "uploaded file analysis panel",
+      "endpoint": "browser local file reader",
+      "evidence_class": "uploaded_text_context",
+      "allowed_tests": [
+        "safe synthetic file analysis",
+        "file truncation behavior",
+        "prompt context boundary evidence",
+        "uploaded-file source labeling"
+      ],
+      "disallowed_tests": [
+        "real secret harvesting",
+        "malware execution",
+        "binary exploitation",
+        "unconsented local file collection"
+      ],
+      "expected_artifacts": [
+        "screenshot",
+        "dom_snapshot",
+        "uploaded_fixture_hash",
+        "evidence_record"
+      ],
+      "article_parts": [
+        "Part 06",
+        "Part 09",
+        "Part 10"
+      ],
+      "toolkit_mapping": {
+        "current": [
+          "uploaded file prompt construction tests"
+        ],
+        "planned": [
+          "fixture manifest linkage"
+        ]
+      }
+    },
+    {
+      "id": "project_agent.guardrail_context",
+      "status": "active",
+      "ui_surface": "Project Agent Add Guardrails button",
+      "endpoint": "/api/project/context",
+      "evidence_class": "project_document_context",
+      "allowed_tests": [
+        "guardrail chunk retrieval",
+        "source path display",
+        "context preview truncation",
+        "untrusted project content boundary prompts"
+      ],
+      "disallowed_tests": [
+        "reading outside allowed workspace roots",
+        "exfiltrating private repositories",
+        "using project content as trusted instruction without boundary labels"
+      ],
+      "expected_artifacts": [
+        "screenshot",
+        "dom_snapshot",
+        "request_response_json",
+        "evidence_record"
+      ],
+      "article_parts": [
+        "Part 06",
+        "Part 09",
+        "Part 28"
+      ],
+      "toolkit_mapping": {
+        "current": [
+          "Project Agent untrusted evidence boundary tests"
+        ],
+        "planned": [
+          "target contract driven Project Agent tests"
+        ]
+      }
+    },
+    {
+      "id": "project_agent.search",
+      "status": "active",
+      "ui_surface": "Project Agent Search button",
+      "endpoint": "/api/project/search",
+      "evidence_class": "project_search_context",
+      "allowed_tests": [
+        "safe local text search",
+        "bounded result count",
+        "source line display",
+        "query traceability"
+      ],
+      "disallowed_tests": [
+        "searching outside configured local roots",
+        "secret hunting in uncontrolled repositories",
+        "unauthorized data collection"
+      ],
+      "expected_artifacts": [
+        "screenshot",
+        "request_response_json",
+        "evidence_record"
+      ],
+      "article_parts": [
+        "Part 06",
+        "Part 28"
+      ],
+      "toolkit_mapping": {
+        "current": [
+          "manual Project Agent search evidence"
+        ],
+        "planned": [
+          "automated search-result boundary tests"
+        ]
+      }
+    },
+    {
+      "id": "project_agent.read_file",
+      "status": "active",
+      "ui_surface": "Project Agent Read File button",
+      "endpoint": "/api/project/read",
+      "evidence_class": "project_file_context",
+      "allowed_tests": [
+        "safe local file fixture reading",
+        "path traversal rejection",
+        "text-file allowlist behavior",
+        "truncation evidence"
+      ],
+      "disallowed_tests": [
+        "reading files outside allowed workspace roots",
+        "reading production secrets",
+        "binary file extraction"
+      ],
+      "expected_artifacts": [
+        "screenshot",
+        "request_response_json",
+        "fixture_hash",
+        "evidence_record"
+      ],
+      "article_parts": [
+        "Part 06",
+        "Part 10",
+        "Part 28"
+      ],
+      "toolkit_mapping": {
+        "current": [
+          "bounded Project Agent file tests"
+        ],
+        "planned": [
+          "contract-linked file fixture evidence"
+        ]
+      }
+    },
+    {
+      "id": "project_agent.run_tool",
+      "status": "active",
+      "ui_surface": "Project Agent Run Tool button",
+      "endpoint": "/api/project/run",
+      "evidence_class": "local_tool_output_context",
+      "allowed_tests": [
+        "allowlisted non-destructive tool execution",
+        "blocked command evidence",
+        "stdout and stderr boundary labeling",
+        "timeout behavior"
+      ],
+      "disallowed_tests": [
+        "destructive commands",
+        "persistence",
+        "credential access",
+        "network exploitation",
+        "shell escape chains"
+      ],
+      "expected_artifacts": [
+        "screenshot",
+        "request_response_json",
+        "tool_output_hash",
+        "evidence_record"
+      ],
+      "article_parts": [
+        "Part 06",
+        "Part 08",
+        "Part 28"
+      ],
+      "toolkit_mapping": {
+        "current": [
+          "allowlisted Project Agent tool-output tests"
+        ],
+        "planned": [
+          "structured tool-output contract assertions"
+        ]
+      }
+    },
+    {
+      "id": "model.catalog_filter",
+      "status": "active",
+      "ui_surface": "model type, model, and size selectors",
+      "endpoint": "/api/models",
+      "evidence_class": "model_selection_context",
+      "allowed_tests": [
+        "model capability filter behavior",
+        "local fallback catalog behavior",
+        "selected model tag traceability"
+      ],
+      "disallowed_tests": [
+        "model provider credential testing",
+        "remote model service abuse"
+      ],
+      "expected_artifacts": [
+        "screenshot",
+        "dom_snapshot",
+        "request_response_json",
+        "evidence_record"
+      ],
+      "article_parts": [
+        "Part 08",
+        "Part 26"
+      ],
+      "toolkit_mapping": {
+        "current": [
+          "manual catalog evidence"
+        ],
+        "planned": [
+          "automated selector state evidence"
+        ]
+      }
+    }
+  ],
+  "traceability_rules": [
+    "Every toolkit test that targets ollama-webui should reference one scenario id from this contract.",
+    "Every evidence record should name the scenario id in the target or metadata when that field exists.",
+    "Documentation must mark unimplemented scenario mappings as planned.",
+    "New vulnerable app features should not be tested by the toolkit until this contract is updated."
+  ]
+}

--- a/docs/target-scenario-contract-v0.2.md
+++ b/docs/target-scenario-contract-v0.2.md
@@ -1,0 +1,71 @@
+# Browser-Safe AI Target Scenario Contract v0.2
+
+This document defines the controlled local lab surfaces that the Browser-Safe AI Systems toolkit is allowed to test in this repository.
+
+The machine-readable contract is:
+
+```text
+docs/target-scenario-contract-v0.2.json
+```
+
+The Flask helper also exposes the same contract at:
+
+```text
+/api/browser-safe/target-contract
+```
+
+## Purpose
+
+The contract keeps the vulnerable app, toolkit, and article series aligned. A toolkit test should not claim coverage against `ollama-webui` unless it maps to a scenario in the contract or is clearly marked as planned.
+
+## Scope
+
+This repository is an intentionally vulnerable local browser-based AI lab target. It is not a secure product and must not be used with production secrets or exposed to public interfaces.
+
+Allowed scope:
+
+- local loopback browser testing
+- local repositories and files owned by the operator
+- safe synthetic fixtures
+- controlled Project Agent guardrail, search, read, and allowlisted tool-output workflows
+- deterministic evidence capture by the toolkit
+
+Out of scope:
+
+- third-party systems
+- credential theft
+- persistence
+- evasion
+- destructive commands
+- public internet exposure
+- production secrets
+
+## Active scenario ids
+
+| Scenario id | Surface | Endpoint or path | Evidence class |
+| --- | --- | --- | --- |
+| `chat.basic_prompt` | Chat form | `/api/generate` | `browser_chat_generation` |
+| `file_upload.text_context` | Uploaded file analysis | Browser local file reader | `uploaded_text_context` |
+| `project_agent.guardrail_context` | Project Agent guardrails | `/api/project/context` | `project_document_context` |
+| `project_agent.search` | Project Agent search | `/api/project/search` | `project_search_context` |
+| `project_agent.read_file` | Project Agent file read | `/api/project/read` | `project_file_context` |
+| `project_agent.run_tool` | Project Agent tool runner | `/api/project/run` | `local_tool_output_context` |
+| `model.catalog_filter` | Model selectors | `/api/models` | `model_selection_context` |
+
+## Traceability rules
+
+1. Every toolkit test that targets `ollama-webui` should reference one scenario id from the JSON contract.
+2. Every evidence record should name the scenario id in the target or metadata when that field exists.
+3. Documentation must mark unimplemented mappings as planned.
+4. New vulnerable app features should not be treated as toolkit coverage until this contract is updated.
+
+## Validation
+
+Run:
+
+```bash
+cd /home/foo/Workspace/ollama-webui
+python scripts/validate_target_contract.py
+```
+
+The validator confirms that the contract has required top-level fields, active scenarios, scenario ids, safety boundaries, expected artifacts, article mappings, and no duplicate scenario ids.

--- a/scripts/pull_model.py
+++ b/scripts/pull_model.py
@@ -25,6 +25,7 @@ from flask import Flask, Response, jsonify, request, send_from_directory, stream
 from werkzeug.exceptions import HTTPException
 
 BASE_DIR = Path(__file__).resolve().parent.parent
+TARGET_CONTRACT_PATH = BASE_DIR / "docs" / "target-scenario-contract-v0.2.json"
 OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "http://127.0.0.1:11434").rstrip("/")
 REQUEST_CONNECT_TIMEOUT_SECONDS = 5
 REQUEST_READ_TIMEOUT_SECONDS = 600
@@ -656,6 +657,19 @@ def api_tags() -> tuple[Response, int]:
 def api_models() -> Response:
     """Return the pullable Ollama model catalog."""
     return jsonify(model_catalog())
+
+
+@app.get("/api/browser-safe/target-contract")
+def api_browser_safe_target_contract() -> tuple[Response, int]:
+    """Return the Browser-Safe AI target scenario contract."""
+    try:
+        payload = json.loads(TARGET_CONTRACT_PATH.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return jsonify({"error": "target scenario contract is missing"}), 500
+    except json.JSONDecodeError as exc:
+        return jsonify({"error": f"target scenario contract is invalid JSON: {exc}"}), 500
+
+    return jsonify(payload), 200
 
 
 @app.get("/api/project/defaults")

--- a/scripts/validate_target_contract.py
+++ b/scripts/validate_target_contract.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Validate the Browser-Safe AI target scenario contract."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONTRACT_PATH = REPO_ROOT / "docs" / "target-scenario-contract-v0.2.json"
+SCHEMA_VERSION = "browser-safe-ai-target-contract/v0.2"
+SCENARIO_ID_RE = re.compile(r"^[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)+$")
+SHA_SAFE_STATUSES = {"active", "planned", "deprecated"}
+REQUIRED_SCENARIO_FIELDS = {
+    "id",
+    "status",
+    "ui_surface",
+    "endpoint",
+    "evidence_class",
+    "allowed_tests",
+    "disallowed_tests",
+    "expected_artifacts",
+    "article_parts",
+    "toolkit_mapping",
+}
+REQUIRED_SCENARIOS = {
+    "chat.basic_prompt",
+    "file_upload.text_context",
+    "project_agent.guardrail_context",
+    "project_agent.search",
+    "project_agent.read_file",
+    "project_agent.run_tool",
+    "model.catalog_filter",
+}
+
+
+def fail(message: str) -> None:
+    """Print a validation error and exit."""
+    print(f"target contract validation failed: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def require_mapping(value: Any, name: str) -> dict[str, Any]:
+    """Return a dictionary value or fail."""
+    if not isinstance(value, dict):
+        fail(f"{name} must be an object")
+    return value
+
+
+def require_non_empty_list(value: Any, name: str) -> list[Any]:
+    """Return a non-empty list value or fail."""
+    if not isinstance(value, list) or not value:
+        fail(f"{name} must be a non-empty list")
+    return value
+
+
+def require_non_empty_string(value: Any, name: str) -> str:
+    """Return a non-empty string value or fail."""
+    if not isinstance(value, str) or not value.strip():
+        fail(f"{name} must be a non-empty string")
+    return value
+
+
+def validate_safety_boundaries(payload: dict[str, Any]) -> None:
+    """Validate the safety boundary section."""
+    boundaries = require_mapping(payload.get("safety_boundaries"), "safety_boundaries")
+    for field in ("authorized_scope", "out_of_scope", "operator_requirements"):
+        entries = require_non_empty_list(boundaries.get(field), f"safety_boundaries.{field}")
+        for index, entry in enumerate(entries):
+            require_non_empty_string(entry, f"safety_boundaries.{field}[{index}]")
+
+
+def validate_global_limits(payload: dict[str, Any]) -> None:
+    """Validate global size and timeout limits."""
+    limits = require_mapping(payload.get("global_limits"), "global_limits")
+    required_limits = {
+        "max_file_bytes",
+        "max_file_context_chars",
+        "max_total_file_context_chars",
+        "max_project_context_chars",
+        "project_helper_max_file_bytes",
+        "project_helper_max_search_file_bytes",
+        "project_helper_max_command_output_chars",
+        "project_helper_command_timeout_seconds",
+    }
+    missing = required_limits - set(limits)
+    if missing:
+        fail(f"global_limits missing required fields: {', '.join(sorted(missing))}")
+
+    for field in sorted(required_limits):
+        value = limits[field]
+        if not isinstance(value, int) or value <= 0:
+            fail(f"global_limits.{field} must be a positive integer")
+
+
+def validate_scenario(scenario: Any, index: int) -> str:
+    """Validate one scenario and return its id."""
+    item = require_mapping(scenario, f"scenarios[{index}]")
+    missing = REQUIRED_SCENARIO_FIELDS - set(item)
+    if missing:
+        fail(f"scenarios[{index}] missing required fields: {', '.join(sorted(missing))}")
+
+    scenario_id = require_non_empty_string(item.get("id"), f"scenarios[{index}].id")
+    if not SCENARIO_ID_RE.fullmatch(scenario_id):
+        fail(f"invalid scenario id: {scenario_id}")
+
+    status = require_non_empty_string(item.get("status"), f"{scenario_id}.status")
+    if status not in SHA_SAFE_STATUSES:
+        fail(f"{scenario_id}.status must be one of: {', '.join(sorted(SHA_SAFE_STATUSES))}")
+
+    for field in ("ui_surface", "endpoint", "evidence_class"):
+        require_non_empty_string(item.get(field), f"{scenario_id}.{field}")
+
+    for field in ("allowed_tests", "disallowed_tests", "expected_artifacts", "article_parts"):
+        values = require_non_empty_list(item.get(field), f"{scenario_id}.{field}")
+        for value_index, value in enumerate(values):
+            require_non_empty_string(value, f"{scenario_id}.{field}[{value_index}]")
+
+    mapping = require_mapping(item.get("toolkit_mapping"), f"{scenario_id}.toolkit_mapping")
+    for field in ("current", "planned"):
+        values = require_non_empty_list(mapping.get(field), f"{scenario_id}.toolkit_mapping.{field}")
+        for value_index, value in enumerate(values):
+            require_non_empty_string(value, f"{scenario_id}.toolkit_mapping.{field}[{value_index}]")
+
+    return scenario_id
+
+
+def validate_contract(payload: dict[str, Any]) -> None:
+    """Validate the complete target contract."""
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        fail(f"schema_version must be {SCHEMA_VERSION}")
+
+    target = require_mapping(payload.get("target"), "target")
+    if target.get("name") != "ollama-webui":
+        fail("target.name must be ollama-webui")
+    if target.get("production_safe") is not False:
+        fail("target.production_safe must be false")
+    for field in ("role", "repository", "local_base_url", "allowed_environment"):
+        require_non_empty_string(target.get(field), f"target.{field}")
+
+    validate_safety_boundaries(payload)
+    validate_global_limits(payload)
+
+    scenarios = require_non_empty_list(payload.get("scenarios"), "scenarios")
+    seen: set[str] = set()
+    for index, scenario in enumerate(scenarios):
+        scenario_id = validate_scenario(scenario, index)
+        if scenario_id in seen:
+            fail(f"duplicate scenario id: {scenario_id}")
+        seen.add(scenario_id)
+
+    missing_required = REQUIRED_SCENARIOS - seen
+    if missing_required:
+        fail(f"missing required scenarios: {', '.join(sorted(missing_required))}")
+
+    traceability_rules = require_non_empty_list(payload.get("traceability_rules"), "traceability_rules")
+    for index, rule in enumerate(traceability_rules):
+        require_non_empty_string(rule, f"traceability_rules[{index}]")
+
+
+def main() -> None:
+    """Load and validate the contract file."""
+    try:
+        payload = json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        fail(f"missing contract file: {CONTRACT_PATH}")
+    except json.JSONDecodeError as exc:
+        fail(f"invalid JSON: {exc}")
+
+    validate_contract(require_mapping(payload, "contract"))
+    print(f"validated target contract: {CONTRACT_PATH}")
+    print(f"scenario count: {len(payload['scenarios'])}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds an explicit Browser-Safe AI target scenario contract to the intentionally vulnerable local Ollama Web UI app.

This contract gives the toolkit a declared, reviewable local target surface before additional toolkit tests are added. It helps prevent the toolkit from claiming coverage for target behavior that the vulnerable app has not published.

## What changed

- Adds a machine-readable target scenario contract at `docs/target-scenario-contract-v0.2.json`.
- Adds a human-readable contract explanation at `docs/target-scenario-contract-v0.2.md`.
- Adds `scripts/validate_target_contract.py` for local contract validation.
- Adds `/api/browser-safe/target-contract` to expose the contract from the local Flask app.
- Updates the README with the target contract purpose, endpoint, and safety boundaries.

## Declared scenario ids

- `chat.basic_prompt`
- `file_upload.text_context`
- `model.catalog_filter`
- `project_agent.guardrail_context`
- `project_agent.read_file`
- `project_agent.run_tool`
- `project_agent.search`

## Safety boundaries

This PR does not harden the vulnerable app and does not add third-party testing capability. The app remains a local intentionally vulnerable target for defensive Browser-Safe AI Systems validation.

The contract keeps the following out of scope:

- third-party systems
- credential theft
- persistence
- unauthorized access
- exploit automation against external targets

## Validation

Local verification completed successfully:

- three-repo sync check captured
- clean Git status
- Python compile check passed
- target contract JSON parsed successfully
- target contract validator passed
- Flask test-client endpoint smoke passed
- Git whitespace check passed
- branch pushed to origin

Verified branch:

`dev/ollama-webui-target-contract-v0.2`

Verified commit:

`186daf072319f1b37266d9307622948356efb4e8`
