### PR TITLE
add redirect-chain target scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,3 +259,14 @@ OLLAMA_HOST='http://127.0.0.1:11434' python scripts/pull_model.py
 ## License
 
 MIT License
+
+### Browser-Safe redirect-chain lab target
+
+The local helper includes a deterministic redirect-chain lab surface for Browser-Safe AI Systems guided labs:
+
+```text
+/browser-safe/redirect/start?variant=baseline
+/api/browser-safe/redirect-chain/scenarios
+```
+
+The redirect-chain target remains local-only and uses safe synthetic content. It is intended for free and open-source tooling such as `curl`, browser developer tools, and purpose-built Python helpers supplied by the project.

--- a/docs/target-scenario-contract-v0.2.json
+++ b/docs/target-scenario-contract-v0.2.json
@@ -78,6 +78,50 @@
       }
     },
     {
+      "id": "browser.redirect_chain",
+      "status": "active",
+      "ui_surface": "Browser-Safe redirect-chain lab pages",
+      "endpoint": "/browser-safe/redirect/start",
+      "evidence_class": "redirect_chain_context",
+      "allowed_tests": [
+        "local-only redirect hop observation",
+        "safe synthetic multistage lure tracing",
+        "final rendered page comparison",
+        "redirect-chain evidence capture"
+      ],
+      "disallowed_tests": [
+        "external redirect targets",
+        "credential collection",
+        "third-party tracking",
+        "open redirect exploitation against public systems"
+      ],
+      "expected_artifacts": [
+        "redirect_chain_json",
+        "http_status_sequence",
+        "final_url",
+        "final_page_html",
+        "evidence_record"
+      ],
+      "article_parts": [
+        "Part 13",
+        "Part 15",
+        "Part 24",
+        "Part 25",
+        "Part 26"
+      ],
+      "toolkit_mapping": {
+        "guided_lab_id": "guided.redirect_chain_evidence",
+        "implementation_status": "target-ready",
+        "current": [
+          "Guided Lab Mode planned redirect-chain evidence record"
+        ],
+        "planned": [
+          "toolkit redirect-chain evidence capture",
+          "guided redirect-chain lab implementation"
+        ]
+      }
+    },
+    {
       "id": "file_upload.text_context",
       "status": "active",
       "ui_surface": "uploaded file analysis panel",

--- a/docs/target-scenario-contract-v0.2.md
+++ b/docs/target-scenario-contract-v0.2.md
@@ -45,12 +45,49 @@ Out of scope:
 | Scenario id | Surface | Endpoint or path | Evidence class |
 | --- | --- | --- | --- |
 | `chat.basic_prompt` | Chat form | `/api/generate` | `browser_chat_generation` |
+| `browser.redirect_chain` | Browser-Safe redirect-chain lab pages | `/browser-safe/redirect/start` | `redirect_chain_context` |
 | `file_upload.text_context` | Uploaded file analysis | Browser local file reader | `uploaded_text_context` |
 | `project_agent.guardrail_context` | Project Agent guardrails | `/api/project/context` | `project_document_context` |
 | `project_agent.search` | Project Agent search | `/api/project/search` | `project_search_context` |
 | `project_agent.read_file` | Project Agent file read | `/api/project/read` | `project_file_context` |
 | `project_agent.run_tool` | Project Agent tool runner | `/api/project/run` | `local_tool_output_context` |
 | `model.catalog_filter` | Model selectors | `/api/models` | `model_selection_context` |
+
+## Redirect-chain local lab surface
+
+The redirect-chain lab surface is intentionally local and deterministic. It is used to teach and validate how staged browser navigation can change what a browser-based AI system observes.
+
+Entry point:
+
+```text
+/browser-safe/redirect/start
+```
+
+Supported safe variants:
+
+```text
+baseline
+encoded
+slow
+```
+
+Example local checks with free and open-source tooling:
+
+```bash
+curl -i -L http://127.0.0.1:11435/browser-safe/redirect/start?variant=baseline
+python -m urllib.request http://127.0.0.1:11435/browser-safe/redirect/start?variant=encoded
+```
+
+The surface never redirects to third-party systems. Each hop remains under the local Flask helper and ends at a synthetic browser-safe evidence page.
+
+Toolkit mapping:
+
+```text
+guided_lab_id: guided.redirect_chain_evidence
+implementation_status: target-ready
+```
+
+The `target-ready` status means the vulnerable app exposes the local target behavior and the toolkit may implement evidence capture in a separate branch. It does not mean the toolkit lab is already implemented.
 
 ## Traceability rules
 

--- a/scripts/pull_model.py
+++ b/scripts/pull_model.py
@@ -21,7 +21,7 @@ from threading import Lock
 from typing import Any, Iterator
 
 import requests
-from flask import Flask, Response, jsonify, request, send_from_directory, stream_with_context
+from flask import Flask, Response, jsonify, redirect, request, send_from_directory, stream_with_context
 from werkzeug.exceptions import HTTPException
 
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -91,6 +91,62 @@ MAX_PROJECT_CONTEXT_CHARS = 18000
 MAX_PROJECT_CHUNK_CHARS = 2200
 MAX_PROJECT_COMMAND_OUTPUT_CHARS = 30000
 PROJECT_COMMAND_TIMEOUT_SECONDS = 120
+REDIRECT_CHAIN_VARIANTS: dict[str, list[dict[str, str]]] = {
+    "baseline": [
+        {
+            "hop": "1",
+            "label": "initial local lure",
+            "description": "The first page redirects to a local intermediate page.",
+        },
+        {
+            "hop": "2",
+            "label": "intermediate local hop",
+            "description": "The intermediate hop adds benign browser-safe context.",
+        },
+        {
+            "hop": "final",
+            "label": "final synthetic page",
+            "description": "The final page displays the controlled local test message.",
+        },
+    ],
+    "encoded": [
+        {
+            "hop": "1",
+            "label": "encoded local lure",
+            "description": "The first page carries URL-encoded synthetic context.",
+        },
+        {
+            "hop": "2",
+            "label": "decoded local hop",
+            "description": "The intermediate hop exposes the encoded context as text.",
+        },
+        {
+            "hop": "final",
+            "label": "final synthetic page",
+            "description": "The final page displays the decoded local-only message.",
+        },
+    ],
+    "slow": [
+        {
+            "hop": "1",
+            "label": "delayed local lure",
+            "description": "The first page simulates a staged navigation without external traffic.",
+        },
+        {
+            "hop": "2",
+            "label": "delayed local hop",
+            "description": "The intermediate hop records a benign delayed-navigation marker.",
+        },
+        {
+            "hop": "final",
+            "label": "final synthetic page",
+            "description": "The final page displays the local staged-navigation result.",
+        },
+    ],
+}
+REDIRECT_CHAIN_DEFAULT_VARIANT = "baseline"
+REDIRECT_CHAIN_LAB_ID = "guided.redirect_chain_evidence"
+REDIRECT_CHAIN_SCENARIO_ID = "browser.redirect_chain"
 ALLOWED_CARGO_SUBCOMMANDS = {"build", "check", "clippy", "fmt", "metadata", "test"}
 ALLOWED_GIT_SUBCOMMANDS = {"diff", "log", "show", "status"}
 ALLOWED_PYTHON_MODULES = {"compileall", "mypy", "py_compile", "pytest", "ruff", "unittest"}
@@ -627,6 +683,64 @@ def project_command_env() -> dict[str, str]:
     return env
 
 
+def redirect_chain_variant(value: object) -> str:
+    """Return a supported redirect-chain variant."""
+    candidate = str(value or REDIRECT_CHAIN_DEFAULT_VARIANT).strip().lower()
+    if candidate not in REDIRECT_CHAIN_VARIANTS:
+        return REDIRECT_CHAIN_DEFAULT_VARIANT
+    return candidate
+
+
+def redirect_chain_hops(variant: str) -> list[dict[str, str]]:
+    """Return hop metadata for a redirect-chain variant."""
+    return REDIRECT_CHAIN_VARIANTS[redirect_chain_variant(variant)]
+
+
+def redirect_chain_url(path: str, variant: str) -> str:
+    """Build a local-only redirect-chain URL."""
+    return f"{path}?variant={redirect_chain_variant(variant)}"
+
+
+def redirect_chain_html(variant: str) -> str:
+    """Render the final redirect-chain page as deterministic HTML."""
+    hops = redirect_chain_hops(variant)
+    hop_items = "\n".join(
+        f"<li><strong>{hop['hop']}</strong>: {hop['label']} - {hop['description']}</li>"
+        for hop in hops
+    )
+    return f"""<!doctype html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"utf-8\">
+  <title>Browser-Safe AI Redirect Chain Lab</title>
+  <meta name=\"browser-safe-ai-lab\" content=\"{REDIRECT_CHAIN_LAB_ID}\">
+  <meta name=\"browser-safe-ai-scenario\" content=\"{REDIRECT_CHAIN_SCENARIO_ID}\">
+</head>
+<body>
+  <main>
+    <h1>Browser-Safe AI Redirect Chain Lab</h1>
+    <p id=\"lab-purpose\">This local-only page demonstrates staged browser navigation for evidence capture.</p>
+    <dl>
+      <dt>Lab id</dt>
+      <dd>{REDIRECT_CHAIN_LAB_ID}</dd>
+      <dt>Target scenario</dt>
+      <dd>{REDIRECT_CHAIN_SCENARIO_ID}</dd>
+      <dt>Variant</dt>
+      <dd>{redirect_chain_variant(variant)}</dd>
+    </dl>
+    <h2>Observed local hops</h2>
+    <ol id=\"redirect-hop-summary\">
+      {hop_items}
+    </ol>
+    <p id=\"safety-boundary\">All redirects remain on 127.0.0.1 and use synthetic data only.</p>
+  </main>
+</body>
+</html>
+"""
+
+
+
+
 @app.get("/")
 def serve_index() -> Response:
     """Serve the main Web UI."""
@@ -670,6 +784,69 @@ def api_browser_safe_target_contract() -> tuple[Response, int]:
         return jsonify({"error": f"target scenario contract is invalid JSON: {exc}"}), 500
 
     return jsonify(payload), 200
+
+
+
+
+@app.get("/api/browser-safe/redirect-chain/scenarios")
+def api_browser_safe_redirect_chain_scenarios() -> Response:
+    """Return local redirect-chain lab metadata."""
+    variants = {
+        name: {
+            "entrypoint": redirect_chain_url("/browser-safe/redirect/start", name),
+            "final": redirect_chain_url("/browser-safe/redirect/final", name),
+            "hops": hops,
+        }
+        for name, hops in REDIRECT_CHAIN_VARIANTS.items()
+    }
+    return jsonify(
+        {
+            "lab_id": REDIRECT_CHAIN_LAB_ID,
+            "target_scenario_id": REDIRECT_CHAIN_SCENARIO_ID,
+            "local_only": True,
+            "free_and_open_source_tooling": True,
+            "variants": variants,
+        }
+    )
+
+
+@app.get("/browser-safe/redirect/start")
+def browser_safe_redirect_start() -> Response:
+    """Start a deterministic local-only redirect chain."""
+    variant = redirect_chain_variant(request.args.get("variant"))
+    response = redirect(redirect_chain_url("/browser-safe/redirect/hop/1", variant), code=302)
+    response.headers["X-Browser-Safe-Lab"] = REDIRECT_CHAIN_LAB_ID
+    response.headers["X-Browser-Safe-Scenario"] = REDIRECT_CHAIN_SCENARIO_ID
+    response.headers["X-Browser-Safe-Hop"] = "start"
+    return response
+
+
+@app.get("/browser-safe/redirect/hop/<int:hop_number>")
+def browser_safe_redirect_hop(hop_number: int) -> Response | tuple[Response, int]:
+    """Continue a deterministic local-only redirect chain."""
+    variant = redirect_chain_variant(request.args.get("variant"))
+    if hop_number not in {1, 2}:
+        return jsonify({"error": "redirect hop must be 1 or 2"}), 404
+
+    next_path = "/browser-safe/redirect/hop/2" if hop_number == 1 else "/browser-safe/redirect/final"
+    response = redirect(redirect_chain_url(next_path, variant), code=302)
+    response.headers["X-Browser-Safe-Lab"] = REDIRECT_CHAIN_LAB_ID
+    response.headers["X-Browser-Safe-Scenario"] = REDIRECT_CHAIN_SCENARIO_ID
+    response.headers["X-Browser-Safe-Hop"] = str(hop_number)
+    return response
+
+
+@app.get("/browser-safe/redirect/final")
+def browser_safe_redirect_final() -> Response:
+    """Return the final deterministic redirect-chain lab page."""
+    variant = redirect_chain_variant(request.args.get("variant"))
+    html = redirect_chain_html(variant)
+    response = Response(html, mimetype="text/html")
+    response.headers["X-Browser-Safe-Lab"] = REDIRECT_CHAIN_LAB_ID
+    response.headers["X-Browser-Safe-Scenario"] = REDIRECT_CHAIN_SCENARIO_ID
+    response.headers["X-Browser-Safe-Hop"] = "final"
+    response.headers["Cache-Control"] = "no-store"
+    return response
 
 
 @app.get("/api/project/defaults")

--- a/scripts/validate_target_contract.py
+++ b/scripts/validate_target_contract.py
@@ -28,6 +28,7 @@ REQUIRED_SCENARIO_FIELDS = {
 }
 REQUIRED_SCENARIOS = {
     "chat.basic_prompt",
+    "browser.redirect_chain",
     "file_upload.text_context",
     "project_agent.guardrail_context",
     "project_agent.search",
@@ -124,6 +125,24 @@ def validate_scenario(scenario: Any, index: int) -> str:
         values = require_non_empty_list(mapping.get(field), f"{scenario_id}.toolkit_mapping.{field}")
         for value_index, value in enumerate(values):
             require_non_empty_string(value, f"{scenario_id}.toolkit_mapping.{field}[{value_index}]")
+
+    if scenario_id == "browser.redirect_chain":
+        guided_lab_id = require_non_empty_string(
+            mapping.get("guided_lab_id"),
+            f"{scenario_id}.toolkit_mapping.guided_lab_id",
+        )
+        if guided_lab_id != "guided.redirect_chain_evidence":
+            fail(
+                f"{scenario_id}.toolkit_mapping.guided_lab_id "
+                "must be guided.redirect_chain_evidence"
+            )
+
+        implementation_status = require_non_empty_string(
+            mapping.get("implementation_status"),
+            f"{scenario_id}.toolkit_mapping.implementation_status",
+        )
+        if implementation_status != "target-ready":
+            fail(f"{scenario_id}.toolkit_mapping.implementation_status must be target-ready")
 
     return scenario_id
 


### PR DESCRIPTION
## Summary

Adds a local-only redirect-chain target scenario to the intentionally vulnerable `ollama-webui` Browser-Safe AI Systems lab target.

This PR updates the target contract before the toolkit claims implemented redirect-chain guided lab coverage. The scenario gives the toolkit a deterministic local surface for future redirect-chain evidence capture.

## What changed

- Adds the active target scenario `browser.redirect_chain`.
- Adds redirect-chain metadata at `/api/browser-safe/redirect-chain/scenarios`.
- Adds local-only redirect-chain lab pages:
  - `/browser-safe/redirect/start`
  - `/browser-safe/redirect/hop/1`
  - `/browser-safe/redirect/hop/2`
  - `/browser-safe/redirect/final`
- Adds safe variants:
  - `baseline`
  - `encoded`
  - `slow`
- Updates `docs/target-scenario-contract-v0.2.json`.
- Updates `docs/target-scenario-contract-v0.2.md`.
- Updates `scripts/validate_target_contract.py`.
- Updates README with the redirect-chain lab target notes.

## Traceability

Target scenario:

`browser.redirect_chain`

Guided lab mapping:

`guided.redirect_chain_evidence`

Implementation status:

`target-ready`

## Safety boundary

The scenario is local-only and uses safe synthetic content. It does not provide external redirect targets, credential collection, third-party tracking, or open redirect exploitation behavior.

## Tooling policy

The target supports the project requirement that guided lab tooling must be free and open source.

If suitable free and open-source tooling is unavailable for a future lab requirement, the project must provide a purpose-built Python helper.

## What this proves

- The vulnerable app can declare a redirect-chain target scenario.
- The target contract validates with eight scenarios.
- The redirect-chain endpoint chain is deterministic.
- The scenario is traceable to the planned guided lab.
- The scenario supports baseline, encoded, and slow safe variants.
- The target remains local-only.

## What this does not claim yet

This PR does not implement toolkit-side redirect-chain evidence capture.

That will be a later toolkit slice after this target scenario is merged.

## Validation

Local verification completed successfully:

- clean Git status
- Python compile passed
- target contract JSON parse passed
- target contract validator passed
- redirect-chain endpoint smoke passed
- free and open-source tooling policy smoke passed
- Git whitespace check passed
- branch pushed to origin

Verified branch:

`dev/ollama-webui-redirect-chain-target-v0.2`

Verified commit:

`1c014a3a1d486bf87e93f7e65814bf853d54d919`
