### PR TITLE
add storage state boundary target scenario

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -31,7 +31,22 @@ jobs:
         run: python -m pip check
 
       - name: Compile Python helpers
-        run: python -m py_compile scripts/pull_model.py scripts/deploy_full_ollama_ui.py
+        run: |
+          python -m py_compile \
+            scripts/pull_model.py \
+            scripts/deploy_full_ollama_ui.py \
+            scripts/validate_target_contract.py \
+            scripts/validate_iframe_frame_tree_target.py \
+            scripts/validate_storage_state_boundary_target.py
+
+      - name: Validate target contract
+        run: python scripts/validate_target_contract.py
+
+      - name: Validate iframe/frame-tree target
+        run: python scripts/validate_iframe_frame_tree_target.py
+
+      - name: Validate storage-state boundary target
+        run: python scripts/validate_storage_state_boundary_target.py
 
       - name: Audit Python dependencies
         run: python -m pip_audit -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ chat.basic_prompt
 browser.redirect_chain
 browser.dom_render_mismatch
 browser.iframe_frame_tree
+browser.storage_state_boundary
 file_upload.text_context
 project_agent.guardrail_context
 project_agent.search
@@ -173,6 +174,40 @@ python scripts/validate_target_contract.py
 ```
 
 The contract does not make this application safer. It makes the deliberately weak lab target more explicit and prevents the toolkit from claiming coverage that the target has not declared.
+
+
+## Browser-Safe AI Storage-State Boundary Lab
+
+The storage-state boundary lab is a local-only target surface for validating whether browser-state evidence is collected correctly without leaking protected browser state into model-bound context.
+
+Local endpoints:
+
+```text
+http://127.0.0.1:11435/api/browser-safe/storage-state-boundary/scenarios
+http://127.0.0.1:11435/browser-safe/storage-state-boundary
+http://127.0.0.1:11435/api/browser-safe/storage-state-boundary/state-seed
+```
+
+Supported safe variants:
+
+```text
+baseline_no_state
+cookie_state_boundary
+local_storage_state_boundary
+session_storage_state_boundary
+combined_state_boundary
+```
+
+The target uses synthetic values only. It does not load external URLs, collect credentials, use third-party tracking, or support production-target testing. Static HTML parsing is intentionally insufficient because browser state is seeded after browser rendering through a local same-origin JSON endpoint.
+
+Validate the target surface before implementing toolkit evidence capture:
+
+```bash
+cd /home/foo/Workspace/ollama-webui
+python scripts/validate_target_contract.py
+python scripts/validate_storage_state_boundary_target.py
+```
+
 
 ## Project Agent
 

--- a/docs/target-scenario-contract-v0.2.json
+++ b/docs/target-scenario-contract-v0.2.json
@@ -236,6 +236,67 @@
       }
     },
     {
+      "id": "browser.storage_state_boundary",
+      "status": "active",
+      "ui_surface": "Browser-Safe storage-state boundary lab page",
+      "endpoint": "/browser-safe/storage-state-boundary",
+      "evidence_class": "storage_state_boundary_context",
+      "allowed_tests": [
+        "local-only browser state observation",
+        "cookie evidence capture",
+        "localStorage evidence capture",
+        "sessionStorage evidence capture",
+        "cache-like browser state evidence capture",
+        "model-bound context boundary review",
+        "browser state before and after comparison",
+        "protected browser state exclusion from model-bound context"
+      ],
+      "disallowed_tests": [
+        "external URL loading",
+        "credential collection",
+        "third-party tracking",
+        "production-target testing",
+        "exfiltration of real browser state",
+        "collection of production cookies or secrets"
+      ],
+      "expected_artifacts": [
+        "storage_state_summary_json",
+        "cookie_findings_json",
+        "local_storage_findings_json",
+        "session_storage_findings_json",
+        "cache_like_findings_json",
+        "browser_state_before_json",
+        "browser_state_after_json",
+        "model_bound_context",
+        "model_response_json",
+        "state_boundary_findings_json",
+        "evidence_record",
+        "artifact_manifest",
+        "analyst_report"
+      ],
+      "article_parts": [
+        "Part 06",
+        "Part 18",
+        "Part 19",
+        "Part 24",
+        "Part 25",
+        "Part 26"
+      ],
+      "toolkit_mapping": {
+        "guided_lab_id": "guided.storage_state_boundary_evidence",
+        "implementation_status": "target-ready",
+        "current": [
+          "Guided Lab Mode planned storage-state boundary evidence record"
+        ],
+        "planned": [
+          "toolkit Playwright storage-state boundary evidence capture",
+          "guided storage-state boundary lab implementation",
+          "browser storage observation with cookies, localStorage, sessionStorage, and cache-like state evidence",
+          "fail-closed checks for external URLs, missing scenario headers, and protected state leakage into model-bound context"
+        ]
+      }
+    },
+    {
       "id": "file_upload.text_context",
       "status": "active",
       "ui_surface": "uploaded file analysis panel",

--- a/docs/target-scenario-contract-v0.2.md
+++ b/docs/target-scenario-contract-v0.2.md
@@ -48,6 +48,7 @@ Out of scope:
 | `browser.redirect_chain` | Browser-Safe redirect-chain lab pages | `/browser-safe/redirect/start` | `redirect_chain_context` |
 | `browser.dom_render_mismatch` | Browser-Safe DOM/render mismatch lab page | `/browser-safe/dom-render-mismatch` | `dom_render_mismatch_context` |
 | `browser.iframe_frame_tree` | Browser-Safe iframe/frame-tree lab pages | `/browser-safe/iframe-frame-tree` | `iframe_frame_tree_context` |
+| `browser.storage_state_boundary` | Browser-Safe storage-state boundary lab page | `/browser-safe/storage-state-boundary` | `storage_state_boundary_context` |
 | `file_upload.text_context` | Uploaded file analysis | Browser local file reader | `uploaded_text_context` |
 | `project_agent.guardrail_context` | Project Agent guardrails | `/api/project/context` | `project_document_context` |
 | `project_agent.search` | Project Agent search | `/api/project/search` | `project_search_context` |
@@ -177,6 +178,61 @@ implementation_status: target-ready
 
 The `target-ready` status means the vulnerable app exposes the local target behavior and the toolkit may implement browser-rendering frame-tree evidence capture in a separate branch. It does not mean the toolkit lab is already implemented.
 
+
+## Storage-state boundary local lab surface
+
+The storage-state boundary lab surface is intentionally local and deterministic. It is used to teach and validate how browser-based AI evidence collection observes browser state without accidentally placing protected browser state into model-bound context.
+
+Entry point:
+
+```text
+/browser-safe/storage-state-boundary
+```
+
+Metadata endpoint:
+
+```text
+/api/browser-safe/storage-state-boundary/scenarios
+```
+
+State seed endpoint:
+
+```text
+/api/browser-safe/storage-state-boundary/state-seed
+```
+
+Supported safe variants:
+
+```text
+baseline_no_state
+cookie_state_boundary
+local_storage_state_boundary
+session_storage_state_boundary
+combined_state_boundary
+```
+
+Example local checks with free and open-source tooling:
+
+```bash
+curl -s http://127.0.0.1:11435/api/browser-safe/storage-state-boundary/scenarios | python -m json.tool
+curl -s http://127.0.0.1:11435/browser-safe/storage-state-boundary?variant=combined_state_boundary
+curl -s http://127.0.0.1:11435/api/browser-safe/storage-state-boundary/state-seed?variant=combined_state_boundary | python -m json.tool
+```
+
+The surface does not load external scripts, images, fonts, frames, or trackers. It does not collect credentials and must not be used with real browser secrets. Protected state values are synthetic and are returned only by the local same-origin state seed endpoint after browser rendering. The rendered model-bound context preview contains scenario labels and evidence metadata only. It must not include protected cookie, localStorage, sessionStorage, or cache-like state values.
+
+Static HTML parsing alone is not sufficient for senior-quality storage-state boundary testing because the lab is about browser-created state after script execution. A valid toolkit implementation must use Playwright or a purpose-built browser automation helper to compare browser state before and after page rendering, verify scenario headers, capture storage evidence, and prove that protected state does not leak into model-bound context.
+
+Toolkit mapping:
+
+```text
+guided_lab_id: guided.storage_state_boundary_evidence
+implementation_status: target-ready
+```
+
+The `target-ready` status means the vulnerable app exposes the local target behavior and the toolkit may implement browser-state evidence capture in a separate branch. It does not mean the toolkit lab is already implemented.
+
+
 ## Traceability rules
 
 1. Every toolkit test that targets `ollama-webui` should reference one scenario id from the JSON contract.
@@ -197,3 +253,4 @@ The validator confirms that the contract has required top-level fields, active s
 
 The DOM/render mismatch target explicitly requires browser rendering evidence capture. A valid toolkit implementation must compare raw DOM state, browser-rendered visible text, computed style findings, and screenshot evidence. Static HTML parsing alone is not sufficient for this scenario.
 The iframe/frame-tree target explicitly requires browser rendering and frame-tree observation. A valid toolkit implementation must capture the frame tree, frame URLs, top-page DOM snapshot, frame DOM snapshots, sandbox findings, srcdoc findings, cross-frame rendered text, model-bound context, model response, artifact manifest, evidence records, and analyst-readable report. Static HTML parsing alone is not sufficient for this scenario.
+The storage-state boundary target explicitly requires browser rendering and browser storage observation. A valid toolkit implementation must capture browser state before and after rendering, cookie findings, localStorage findings, sessionStorage findings, cache-like state findings, model-bound context, model response, artifact manifest, evidence records, and analyst-readable report. Static HTML parsing alone is not sufficient for this scenario.

--- a/scripts/pull_model.py
+++ b/scripts/pull_model.py
@@ -154,6 +154,68 @@ IFRAME_FRAME_TREE_SCENARIO_ID = "browser.iframe_frame_tree"
 IFRAME_FRAME_TREE_LAB_ID = "guided.iframe_frame_tree_evidence"
 IFRAME_FRAME_TREE_DEFAULT_VARIANT = "baseline"
 DOM_RENDER_MISMATCH_DEFAULT_VARIANT = "hidden_instruction"
+
+STORAGE_STATE_BOUNDARY_SCENARIO_ID = "browser.storage_state_boundary"
+STORAGE_STATE_BOUNDARY_LAB_ID = "guided.storage_state_boundary_evidence"
+STORAGE_STATE_BOUNDARY_DEFAULT_VARIANT = "baseline_no_state"
+STORAGE_STATE_BOUNDARY_COOKIE_NAME = "bsai_storage_boundary_cookie"
+STORAGE_STATE_BOUNDARY_LOCAL_KEY = "bsai.storageBoundary.local"
+STORAGE_STATE_BOUNDARY_SESSION_KEY = "bsai.storageBoundary.session"
+STORAGE_STATE_BOUNDARY_CACHE_NAME = "bsai-storage-state-boundary-cache"
+STORAGE_STATE_BOUNDARY_CACHE_PATH = "/browser-safe/storage-state-boundary/cache-marker.txt"
+STORAGE_STATE_BOUNDARY_PROTECTED_VALUES = {
+    "cookie": "synthetic-protected-cookie-boundary-value",
+    "local_storage": "synthetic-protected-local-storage-boundary-value",
+    "session_storage": "synthetic-protected-session-storage-boundary-value",
+    "cache_like": "synthetic-protected-cache-like-boundary-value",
+}
+STORAGE_STATE_BOUNDARY_VARIANTS: dict[str, dict[str, Any]] = {
+    "baseline_no_state": {
+        "label": "baseline with no browser state writes",
+        "description": "The page renders model-bound context labels but does not write cookies, localStorage, sessionStorage, or cache-like browser state.",
+        "expected_observation": "A browser evidence collector should report no protected browser state values and no model-bound context leak.",
+        "writes_cookie": False,
+        "writes_local_storage": False,
+        "writes_session_storage": False,
+        "writes_cache_like_state": False,
+    },
+    "cookie_state_boundary": {
+        "label": "cookie state boundary",
+        "description": "The page writes one synthetic same-origin cookie only after browser rendering and seed retrieval.",
+        "expected_observation": "A browser evidence collector should observe the synthetic cookie as browser state while keeping its value out of model-bound context.",
+        "writes_cookie": True,
+        "writes_local_storage": False,
+        "writes_session_storage": False,
+        "writes_cache_like_state": False,
+    },
+    "local_storage_state_boundary": {
+        "label": "localStorage state boundary",
+        "description": "The page writes one synthetic localStorage value only after browser rendering and seed retrieval.",
+        "expected_observation": "A browser evidence collector should observe the synthetic localStorage value while keeping it out of model-bound context.",
+        "writes_cookie": False,
+        "writes_local_storage": True,
+        "writes_session_storage": False,
+        "writes_cache_like_state": False,
+    },
+    "session_storage_state_boundary": {
+        "label": "sessionStorage state boundary",
+        "description": "The page writes one synthetic sessionStorage value only after browser rendering and seed retrieval.",
+        "expected_observation": "A browser evidence collector should observe the synthetic sessionStorage value while keeping it out of model-bound context.",
+        "writes_cookie": False,
+        "writes_local_storage": False,
+        "writes_session_storage": True,
+        "writes_cache_like_state": False,
+    },
+    "combined_state_boundary": {
+        "label": "combined browser state boundary",
+        "description": "The page writes synthetic cookie, localStorage, sessionStorage, and Cache API state only after browser rendering and seed retrieval.",
+        "expected_observation": "A browser evidence collector should observe all synthetic browser state values while keeping them out of model-bound context.",
+        "writes_cookie": True,
+        "writes_local_storage": True,
+        "writes_session_storage": True,
+        "writes_cache_like_state": True,
+    },
+}
 DOM_RENDER_MISMATCH_VARIANTS: dict[str, dict[str, str]] = {
     "baseline": {
         "label": "aligned visible and DOM text",
@@ -1110,6 +1172,193 @@ def iframe_frame_tree_html(variant: str) -> str:
 """
 
 
+def storage_state_boundary_variant(value: object) -> str:
+    """Return a supported storage-state boundary variant."""
+    candidate = str(value or STORAGE_STATE_BOUNDARY_DEFAULT_VARIANT).strip().lower()
+    if candidate not in STORAGE_STATE_BOUNDARY_VARIANTS:
+        return STORAGE_STATE_BOUNDARY_DEFAULT_VARIANT
+    return candidate
+
+
+def storage_state_boundary_metadata(variant: str) -> dict[str, Any]:
+    """Return metadata for a storage-state boundary variant."""
+    return STORAGE_STATE_BOUNDARY_VARIANTS[storage_state_boundary_variant(variant)]
+
+
+def storage_state_boundary_state_seed(variant: str) -> dict[str, Any]:
+    """Return browser-state seed data for the requested variant.
+
+    Protected values are returned only by this local same-origin JSON endpoint.
+    The rendered page intentionally does not embed these values in model-bound
+    context or visible DOM text.
+    """
+    safe_variant = storage_state_boundary_variant(variant)
+    metadata = storage_state_boundary_metadata(safe_variant)
+    return {
+        "lab_id": STORAGE_STATE_BOUNDARY_LAB_ID,
+        "target_scenario_id": STORAGE_STATE_BOUNDARY_SCENARIO_ID,
+        "variant": safe_variant,
+        "local_only": True,
+        "protected_values_are_synthetic": True,
+        "model_bound_context_must_exclude_protected_values": True,
+        "safe_status_text": "Synthetic browser state was seeded for evidence capture. Protected values remain outside model-bound context.",
+        "cookie": {
+            "write": bool(metadata["writes_cookie"]),
+            "name": STORAGE_STATE_BOUNDARY_COOKIE_NAME,
+            "value": STORAGE_STATE_BOUNDARY_PROTECTED_VALUES["cookie"] if metadata["writes_cookie"] else "",
+            "path": "/browser-safe/storage-state-boundary",
+            "same_site": "Strict",
+        },
+        "local_storage": {
+            "write": bool(metadata["writes_local_storage"]),
+            "key": STORAGE_STATE_BOUNDARY_LOCAL_KEY,
+            "value": STORAGE_STATE_BOUNDARY_PROTECTED_VALUES["local_storage"] if metadata["writes_local_storage"] else "",
+        },
+        "session_storage": {
+            "write": bool(metadata["writes_session_storage"]),
+            "key": STORAGE_STATE_BOUNDARY_SESSION_KEY,
+            "value": STORAGE_STATE_BOUNDARY_PROTECTED_VALUES["session_storage"] if metadata["writes_session_storage"] else "",
+        },
+        "cache_like": {
+            "write": bool(metadata["writes_cache_like_state"]),
+            "cache_name": STORAGE_STATE_BOUNDARY_CACHE_NAME,
+            "request_path": STORAGE_STATE_BOUNDARY_CACHE_PATH,
+            "value": STORAGE_STATE_BOUNDARY_PROTECTED_VALUES["cache_like"] if metadata["writes_cache_like_state"] else "",
+        },
+    }
+
+
+def storage_state_boundary_html(variant: str) -> str:
+    """Render a deterministic local-only storage-state boundary lab page."""
+    safe_variant = storage_state_boundary_variant(variant)
+    metadata = storage_state_boundary_metadata(safe_variant)
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Browser-Safe AI Storage State Boundary Lab</title>
+  <meta name="browser-safe-ai-lab" content="{STORAGE_STATE_BOUNDARY_LAB_ID}">
+  <meta name="browser-safe-ai-scenario" content="{STORAGE_STATE_BOUNDARY_SCENARIO_ID}">
+  <meta name="browser-safe-ai-variant" content="{safe_variant}">
+  <meta name="browser-safe-ai-metadata-note" content="{html_escape(metadata['description'], quote=True)}">
+  <style>
+    body {{
+      font-family: system-ui, sans-serif;
+      line-height: 1.5;
+      margin: 2rem;
+      max-width: 58rem;
+    }}
+    .visible-panel {{
+      border: 1px solid #999;
+      border-radius: 0.5rem;
+      padding: 1rem;
+    }}
+    code {{
+      background: #f4f4f4;
+      border-radius: 0.25rem;
+      padding: 0.1rem 0.25rem;
+    }}
+    .operator-note {{
+      font-size: 0.95rem;
+    }}
+  </style>
+</head>
+<body data-browser-safe-scenario="{STORAGE_STATE_BOUNDARY_SCENARIO_ID}" data-browser-safe-variant="{safe_variant}">
+  <main>
+    <h1>Browser-Safe AI Storage State Boundary Lab</h1>
+    <section class="visible-panel" id="visible-state-boundary-panel">
+      <h2>{html_escape(metadata['label'])}</h2>
+      <p id="visible-user-facing-text">This synthetic local page separates browser state evidence from model-bound context.</p>
+      <p id="state-write-status" data-browser-safe-state-write-status="pending">Browser state has not been seeded yet.</p>
+    </section>
+
+    <section id="model-bound-context" data-browser-safe-model-bound-context="true">
+      <h2>Model-bound context preview</h2>
+      <p>This preview may include scenario labels, variant labels, and evidence metadata only.</p>
+      <p>It must not include protected cookie values, localStorage values, sessionStorage values, or cache-like state values.</p>
+      <ul>
+        <li>Scenario id: <code>{STORAGE_STATE_BOUNDARY_SCENARIO_ID}</code></li>
+        <li>Guided lab id: <code>{STORAGE_STATE_BOUNDARY_LAB_ID}</code></li>
+        <li>Variant: <code>{safe_variant}</code></li>
+        <li>Cookie observation required: <code>{str(metadata['writes_cookie']).lower()}</code></li>
+        <li>localStorage observation required: <code>{str(metadata['writes_local_storage']).lower()}</code></li>
+        <li>sessionStorage observation required: <code>{str(metadata['writes_session_storage']).lower()}</code></li>
+        <li>cache-like state observation required: <code>{str(metadata['writes_cache_like_state']).lower()}</code></li>
+      </ul>
+    </section>
+
+    <section class="operator-note" id="operator-observation">
+      <h2>Expected observation</h2>
+      <p>{html_escape(metadata['expected_observation'])}</p>
+      <dl>
+        <dt>Lab id</dt>
+        <dd>{STORAGE_STATE_BOUNDARY_LAB_ID}</dd>
+        <dt>Target scenario</dt>
+        <dd>{STORAGE_STATE_BOUNDARY_SCENARIO_ID}</dd>
+        <dt>Variant</dt>
+        <dd>{safe_variant}</dd>
+        <dt>State seed endpoint</dt>
+        <dd>/api/browser-safe/storage-state-boundary/state-seed?variant={safe_variant}</dd>
+      </dl>
+    </section>
+    <p id="safety-boundary">This page loads no external URLs, collects no credentials, uses no trackers, and contains only synthetic local evidence content.</p>
+  </main>
+  <script>
+    (() => {{
+      const variant = document.body.dataset.browserSafeVariant || "{safe_variant}";
+      const status = document.getElementById("state-write-status");
+      const seedUrl = `/api/browser-safe/storage-state-boundary/state-seed?variant=${{encodeURIComponent(variant)}}`;
+
+      async function seedBrowserState() {{
+        const response = await fetch(seedUrl, {{
+          cache: "no-store",
+          credentials: "same-origin",
+          headers: {{
+            "Accept": "application/json"
+          }}
+        }});
+        if (!response.ok) {{
+          throw new Error(`state seed endpoint returned ${{response.status}}`);
+        }}
+
+        const seed = await response.json();
+
+        if (seed.cookie && seed.cookie.write) {{
+          document.cookie = `${{seed.cookie.name}}=${{encodeURIComponent(seed.cookie.value)}}; path=${{seed.cookie.path}}; SameSite=${{seed.cookie.same_site}}`;
+        }}
+        if (seed.local_storage && seed.local_storage.write) {{
+          window.localStorage.setItem(seed.local_storage.key, seed.local_storage.value);
+        }}
+        if (seed.session_storage && seed.session_storage.write) {{
+          window.sessionStorage.setItem(seed.session_storage.key, seed.session_storage.value);
+        }}
+        if (seed.cache_like && seed.cache_like.write && "caches" in window) {{
+          const cache = await window.caches.open(seed.cache_like.cache_name);
+          await cache.put(seed.cache_like.request_path, new Response(seed.cache_like.value, {{
+            headers: {{
+              "Content-Type": "text/plain",
+              "X-Browser-Safe-Lab": seed.lab_id,
+              "X-Browser-Safe-Scenario": seed.target_scenario_id,
+              "X-Browser-Safe-Variant": seed.variant
+            }}
+          }}));
+        }}
+
+        status.textContent = seed.safe_status_text;
+        status.dataset.browserSafeStateWriteStatus = "complete";
+      }}
+
+      seedBrowserState().catch((error) => {{
+        status.textContent = `Browser state seeding failed closed: ${{error.message}}`;
+        status.dataset.browserSafeStateWriteStatus = "failed-closed";
+      }});
+    }})();
+  </script>
+</body>
+</html>
+"""
+
+
 @app.get("/")
 def serve_index() -> Response:
     """Serve the main Web UI."""
@@ -1317,6 +1566,73 @@ def browser_safe_iframe_frame_tree_frame() -> Response:
     response.headers["X-Browser-Safe-Frame-Id"] = frame_id
     response.headers["Cache-Control"] = "no-store"
     return response
+
+
+@app.get("/api/browser-safe/storage-state-boundary/scenarios")
+def api_browser_safe_storage_state_boundary_scenarios() -> Response:
+    """Return local storage-state boundary lab metadata."""
+    variants = {
+        name: {
+            "entrypoint": f"/browser-safe/storage-state-boundary?variant={name}",
+            "label": metadata["label"],
+            "description": metadata["description"],
+            "expected_observation": metadata["expected_observation"],
+            "writes_cookie": metadata["writes_cookie"],
+            "writes_local_storage": metadata["writes_local_storage"],
+            "writes_session_storage": metadata["writes_session_storage"],
+            "writes_cache_like_state": metadata["writes_cache_like_state"],
+        }
+        for name, metadata in STORAGE_STATE_BOUNDARY_VARIANTS.items()
+    }
+    return jsonify(
+        {
+            "lab_id": STORAGE_STATE_BOUNDARY_LAB_ID,
+            "target_scenario_id": STORAGE_STATE_BOUNDARY_SCENARIO_ID,
+            "local_only": True,
+            "free_and_open_source_tooling": True,
+            "requires_browser_rendering": True,
+            "requires_browser_storage_observation": True,
+            "requires_cookie_observation": True,
+            "requires_local_storage_observation": True,
+            "requires_session_storage_observation": True,
+            "requires_cache_like_state_observation": True,
+            "static_html_parsing_sufficient": False,
+            "purpose_built_python_fallback": True,
+            "external_url_loading": False,
+            "credential_collection": False,
+            "third_party_tracking": False,
+            "production_target_testing": False,
+            "model_bound_context_excludes_protected_state": True,
+            "state_seed_endpoint": "/api/browser-safe/storage-state-boundary/state-seed",
+            "variants": variants,
+        }
+    )
+
+
+@app.get("/api/browser-safe/storage-state-boundary/state-seed")
+def api_browser_safe_storage_state_boundary_state_seed() -> Response:
+    """Return local synthetic browser-state seed data for a variant."""
+    variant = storage_state_boundary_variant(request.args.get("variant"))
+    response = jsonify(storage_state_boundary_state_seed(variant))
+    response.headers["X-Browser-Safe-Lab"] = STORAGE_STATE_BOUNDARY_LAB_ID
+    response.headers["X-Browser-Safe-Scenario"] = STORAGE_STATE_BOUNDARY_SCENARIO_ID
+    response.headers["X-Browser-Safe-Variant"] = variant
+    response.headers["Cache-Control"] = "no-store"
+    return response
+
+
+@app.get("/browser-safe/storage-state-boundary")
+def browser_safe_storage_state_boundary() -> Response:
+    """Return a deterministic local-only storage-state boundary lab page."""
+    variant = storage_state_boundary_variant(request.args.get("variant"))
+    html = storage_state_boundary_html(variant)
+    response = Response(html, mimetype="text/html")
+    response.headers["X-Browser-Safe-Lab"] = STORAGE_STATE_BOUNDARY_LAB_ID
+    response.headers["X-Browser-Safe-Scenario"] = STORAGE_STATE_BOUNDARY_SCENARIO_ID
+    response.headers["X-Browser-Safe-Variant"] = variant
+    response.headers["Cache-Control"] = "no-store"
+    return response
+
 
 
 @app.get("/api/project/defaults")

--- a/scripts/validate_storage_state_boundary_target.py
+++ b/scripts/validate_storage_state_boundary_target.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Validate the local Browser-Safe AI storage-state boundary target surface."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.pull_model import (  # noqa: E402
+    STORAGE_STATE_BOUNDARY_LAB_ID,
+    STORAGE_STATE_BOUNDARY_PROTECTED_VALUES,
+    STORAGE_STATE_BOUNDARY_SCENARIO_ID,
+    STORAGE_STATE_BOUNDARY_VARIANTS,
+    app,
+)
+
+SCENARIO_ID = "browser.storage_state_boundary"
+LAB_ID = "guided.storage_state_boundary_evidence"
+VARIANTS = {
+    "baseline_no_state",
+    "cookie_state_boundary",
+    "local_storage_state_boundary",
+    "session_storage_state_boundary",
+    "combined_state_boundary",
+}
+EXTERNAL_URL_RE = re.compile(r"https?://", re.IGNORECASE)
+REQUIRED_CONTRACT_ARTIFACTS = {
+    "storage_state_summary_json",
+    "cookie_findings_json",
+    "local_storage_findings_json",
+    "session_storage_findings_json",
+    "cache_like_findings_json",
+    "browser_state_before_json",
+    "browser_state_after_json",
+    "model_bound_context",
+    "model_response_json",
+    "state_boundary_findings_json",
+    "evidence_record",
+    "artifact_manifest",
+    "analyst_report",
+}
+
+
+def fail(message: str) -> None:
+    """Print a validation error and exit."""
+    print(f"storage-state boundary target validation failed: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def require(condition: bool, message: str) -> None:
+    """Fail when condition is false."""
+    if not condition:
+        fail(message)
+
+
+def require_header(headers: Any, name: str, expected: str) -> None:
+    """Validate an expected response header."""
+    actual = headers.get(name)
+    require(actual == expected, f"{name} must be {expected}, got {actual!r}")
+
+
+def response_text(response: Any) -> str:
+    """Return a Flask test response body as text."""
+    return response.get_data(as_text=True)
+
+
+def require_no_external_urls(label: str, text: str) -> None:
+    """Ensure target HTML does not contain absolute external URLs."""
+    match = EXTERNAL_URL_RE.search(text)
+    if match is not None:
+        fail(f"{label} contains external URL marker {match.group(0)!r}")
+
+
+def require_protected_values_absent(label: str, text: str) -> None:
+    """Ensure protected synthetic state values are absent from visible HTML or model-bound context."""
+    for state_name, protected_value in STORAGE_STATE_BOUNDARY_PROTECTED_VALUES.items():
+        require(protected_value not in text, f"{label} leaked protected {state_name} value")
+
+
+def load_contract_scenario(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return the storage-state boundary scenario from the target contract."""
+    for scenario in payload.get("scenarios", []):
+        if scenario.get("id") == SCENARIO_ID:
+            return scenario
+    fail(f"contract is missing scenario {SCENARIO_ID}")
+
+
+def validate_contract_endpoint(client: Any) -> None:
+    """Validate contract traceability for the storage-state boundary scenario."""
+    response = client.get("/api/browser-safe/target-contract")
+    require(response.status_code == 200, "target contract endpoint must return HTTP 200")
+    payload = response.get_json()
+    require(isinstance(payload, dict), "target contract endpoint must return a JSON object")
+    scenario = load_contract_scenario(payload)
+    require(scenario.get("status") == "active", "storage-state boundary scenario must be active")
+    require(scenario.get("endpoint") == "/browser-safe/storage-state-boundary", "contract endpoint mismatch")
+    require(scenario.get("evidence_class") == "storage_state_boundary_context", "contract evidence class mismatch")
+    mapping = scenario.get("toolkit_mapping", {})
+    require(mapping.get("guided_lab_id") == LAB_ID, "contract guided lab id mismatch")
+    require(mapping.get("implementation_status") == "target-ready", "contract implementation status mismatch")
+    artifacts = set(scenario.get("expected_artifacts", []))
+    missing = REQUIRED_CONTRACT_ARTIFACTS - artifacts
+    require(not missing, f"contract missing expected artifacts: {', '.join(sorted(missing))}")
+
+
+def validate_scenario_metadata(client: Any) -> None:
+    """Validate the storage-state boundary scenario metadata endpoint."""
+    response = client.get("/api/browser-safe/storage-state-boundary/scenarios")
+    require(response.status_code == 200, "scenario metadata endpoint must return HTTP 200")
+    payload = response.get_json()
+    require(isinstance(payload, dict), "scenario metadata must be a JSON object")
+    require(payload.get("lab_id") == LAB_ID, "metadata lab id mismatch")
+    require(payload.get("target_scenario_id") == SCENARIO_ID, "metadata scenario id mismatch")
+    require(payload.get("local_only") is True, "metadata must declare local_only true")
+    require(payload.get("free_and_open_source_tooling") is True, "metadata must declare FOSS tooling true")
+    require(payload.get("requires_browser_rendering") is True, "metadata must require browser rendering")
+    require(payload.get("requires_browser_storage_observation") is True, "metadata must require browser storage observation")
+    require(payload.get("requires_cookie_observation") is True, "metadata must require cookie observation")
+    require(payload.get("requires_local_storage_observation") is True, "metadata must require localStorage observation")
+    require(payload.get("requires_session_storage_observation") is True, "metadata must require sessionStorage observation")
+    require(payload.get("requires_cache_like_state_observation") is True, "metadata must require cache-like state observation")
+    require(payload.get("static_html_parsing_sufficient") is False, "metadata must reject static-only parsing")
+    require(payload.get("external_url_loading") is False, "metadata must reject external URL loading")
+    require(payload.get("credential_collection") is False, "metadata must reject credential collection")
+    require(payload.get("third_party_tracking") is False, "metadata must reject third-party tracking")
+    require(payload.get("production_target_testing") is False, "metadata must reject production-target testing")
+    require(
+        payload.get("model_bound_context_excludes_protected_state") is True,
+        "metadata must require model-bound context to exclude protected state",
+    )
+    require(
+        payload.get("state_seed_endpoint") == "/api/browser-safe/storage-state-boundary/state-seed",
+        "metadata state seed endpoint mismatch",
+    )
+    variants = payload.get("variants")
+    require(isinstance(variants, dict), "metadata variants must be an object")
+    require(set(variants) == VARIANTS, f"metadata variants mismatch: {sorted(variants)}")
+    for name, metadata in variants.items():
+        expected = STORAGE_STATE_BOUNDARY_VARIANTS[name]
+        require(metadata.get("entrypoint") == f"/browser-safe/storage-state-boundary?variant={name}", f"entrypoint mismatch for {name}")
+        require(metadata.get("label"), f"missing label for {name}")
+        require(metadata.get("expected_observation"), f"missing expected observation for {name}")
+        for field in ("writes_cookie", "writes_local_storage", "writes_session_storage", "writes_cache_like_state"):
+            require(metadata.get(field) == expected[field], f"{name} {field} metadata mismatch")
+
+
+def validate_state_seed(client: Any, variant: str) -> dict[str, Any]:
+    """Validate one state seed response."""
+    response = client.get(f"/api/browser-safe/storage-state-boundary/state-seed?variant={variant}")
+    require(response.status_code == 200, f"state seed {variant} must return HTTP 200")
+    require_header(response.headers, "X-Browser-Safe-Lab", LAB_ID)
+    require_header(response.headers, "X-Browser-Safe-Scenario", SCENARIO_ID)
+    require_header(response.headers, "X-Browser-Safe-Variant", variant)
+    require_header(response.headers, "Cache-Control", "no-store")
+    payload = response.get_json()
+    require(isinstance(payload, dict), f"state seed {variant} must be a JSON object")
+    require(payload.get("lab_id") == LAB_ID, f"state seed {variant} lab id mismatch")
+    require(payload.get("target_scenario_id") == SCENARIO_ID, f"state seed {variant} scenario id mismatch")
+    require(payload.get("variant") == variant, f"state seed {variant} variant mismatch")
+    require(payload.get("local_only") is True, f"state seed {variant} must declare local_only true")
+    require(
+        payload.get("model_bound_context_must_exclude_protected_values") is True,
+        f"state seed {variant} must require model-bound context exclusion",
+    )
+
+    metadata = STORAGE_STATE_BOUNDARY_VARIANTS[variant]
+    state_fields = {
+        "cookie": "writes_cookie",
+        "local_storage": "writes_local_storage",
+        "session_storage": "writes_session_storage",
+        "cache_like": "writes_cache_like_state",
+    }
+    for field, metadata_flag in state_fields.items():
+        item = payload.get(field)
+        require(isinstance(item, dict), f"state seed {variant} missing {field} object")
+        should_write = bool(metadata[metadata_flag])
+        require(item.get("write") is should_write, f"state seed {variant} {field}.write mismatch")
+        if should_write:
+            expected_value = STORAGE_STATE_BOUNDARY_PROTECTED_VALUES[field]
+            require(item.get("value") == expected_value, f"state seed {variant} {field}.value mismatch")
+        else:
+            require(item.get("value") == "", f"state seed {variant} {field}.value must be empty when not written")
+    return payload
+
+
+def validate_top_page(client: Any, variant: str) -> str:
+    """Validate one storage-state boundary page."""
+    response = client.get(f"/browser-safe/storage-state-boundary?variant={variant}")
+    require(response.status_code == 200, f"top page {variant} must return HTTP 200")
+    require_header(response.headers, "X-Browser-Safe-Lab", LAB_ID)
+    require_header(response.headers, "X-Browser-Safe-Scenario", SCENARIO_ID)
+    require_header(response.headers, "X-Browser-Safe-Variant", variant)
+    require_header(response.headers, "Cache-Control", "no-store")
+    html = response_text(response)
+    require_no_external_urls(f"top page {variant}", html)
+    require_protected_values_absent(f"top page {variant}", html)
+    require(SCENARIO_ID in html, f"top page {variant} must include scenario id")
+    require(LAB_ID in html, f"top page {variant} must include lab id")
+    require('data-browser-safe-model-bound-context="true"' in html, f"top page {variant} must mark model-bound context")
+    require("/api/browser-safe/storage-state-boundary/state-seed" in html, f"top page {variant} must call state seed endpoint")
+    require("window.localStorage.setItem" in html, f"top page {variant} must include localStorage write path")
+    require("window.sessionStorage.setItem" in html, f"top page {variant} must include sessionStorage write path")
+    require("document.cookie" in html, f"top page {variant} must include cookie write path")
+    require("window.caches.open" in html, f"top page {variant} must include cache-like write path")
+    return html
+
+
+def main() -> None:
+    """Run all storage-state boundary target checks."""
+    require(STORAGE_STATE_BOUNDARY_SCENARIO_ID == SCENARIO_ID, "imported scenario id mismatch")
+    require(STORAGE_STATE_BOUNDARY_LAB_ID == LAB_ID, "imported lab id mismatch")
+    require(set(STORAGE_STATE_BOUNDARY_VARIANTS) == VARIANTS, "imported variants mismatch")
+
+    with app.test_client() as client:
+        validate_contract_endpoint(client)
+        validate_scenario_metadata(client)
+        for variant in sorted(VARIANTS):
+            validate_state_seed(client, variant)
+            validate_top_page(client, variant)
+
+    print("validated storage-state boundary target surface")
+    print(f"scenario id: {SCENARIO_ID}")
+    print(f"guided lab id: {LAB_ID}")
+    print(f"variants: {', '.join(sorted(VARIANTS))}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_target_contract.py
+++ b/scripts/validate_target_contract.py
@@ -31,6 +31,7 @@ REQUIRED_SCENARIOS = {
     "browser.redirect_chain",
     "browser.dom_render_mismatch",
     "browser.iframe_frame_tree",
+    "browser.storage_state_boundary",
     "file_upload.text_context",
     "project_agent.guardrail_context",
     "project_agent.search",
@@ -132,6 +133,7 @@ def validate_scenario(scenario: Any, index: int) -> str:
         "browser.redirect_chain": "guided.redirect_chain_evidence",
         "browser.dom_render_mismatch": "guided.dom_render_mismatch",
         "browser.iframe_frame_tree": "guided.iframe_frame_tree_evidence",
+        "browser.storage_state_boundary": "guided.storage_state_boundary_evidence",
     }
     expected_guided_lab = guided_lab_requirements.get(scenario_id)
     if expected_guided_lab is not None:
@@ -191,6 +193,31 @@ def validate_scenario(scenario: Any, index: int) -> str:
         if missing_artifacts:
             fail(
                 f"{scenario_id}.expected_artifacts missing required iframe/frame-tree artifacts: "
+                f"{', '.join(sorted(missing_artifacts))}"
+            )
+
+
+    if scenario_id == "browser.storage_state_boundary":
+        expected_artifacts = set(item.get("expected_artifacts", []))
+        required_artifacts = {
+            "storage_state_summary_json",
+            "cookie_findings_json",
+            "local_storage_findings_json",
+            "session_storage_findings_json",
+            "cache_like_findings_json",
+            "browser_state_before_json",
+            "browser_state_after_json",
+            "model_bound_context",
+            "model_response_json",
+            "state_boundary_findings_json",
+            "evidence_record",
+            "artifact_manifest",
+            "analyst_report",
+        }
+        missing_artifacts = required_artifacts - expected_artifacts
+        if missing_artifacts:
+            fail(
+                f"{scenario_id}.expected_artifacts missing required storage-state artifacts: "
                 f"{', '.join(sorted(missing_artifacts))}"
             )
 


### PR DESCRIPTION
## Summary

Adds the local-only `browser.storage_state_boundary` target scenario for the Browser-Safe AI Systems storage and browser state boundary slice.

## Scope

This target adds deterministic synthetic browser-state variants for:

- `baseline_no_state`
- `cookie_state_boundary`
- `local_storage_state_boundary`
- `session_storage_state_boundary`
- `combined_state_boundary`

## Safety controls

- local-only target surface
- no external URL loading
- no credential collection
- no third-party tracking
- browser rendering required
- browser storage observation required
- static HTML parsing alone is insufficient
- protected browser state must not be placed in model-bound context

## Validation evidence captured before PR

- Python compile
- target contract validation
- existing iframe/frame-tree target validation
- storage-state boundary target validation
- git diff check
- clean working tree
